### PR TITLE
Make RPC request multiplexing key generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,17 +1,3 @@
-[root]
-name = "topology_generator"
-version = "0.1.1"
-dependencies = [
- "abomonation 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "abomonation_derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "strymon_runtime 0.1.1",
- "timely 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "typename 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "abomonation"
 version = "0.4.6"
@@ -164,6 +150,16 @@ dependencies = [
 name = "dtoa"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "enum-primitive-derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "env_logger"
@@ -482,6 +478,8 @@ dependencies = [
 name = "strymon_rpc"
 version = "0.1.1"
 dependencies = [
+ "enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "strymon_communication 0.1.1",
@@ -672,6 +670,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "topology_generator"
+version = "0.1.1"
+dependencies = [
+ "abomonation 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "abomonation_derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strymon_runtime 0.1.1",
+ "timely 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typename 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typename"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +771,7 @@ dependencies = [
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum differential-dataflow 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d94bf0d387d0b632f1ad5b0696fe93f2506bb66c84537f3b32415cab7f42fcea"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
+"checksum enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b90e520ec62c1864c8c78d637acbfe8baf5f63240f2fb8165b8325c07812dd"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"

--- a/src/strymon_communication/src/rpc.rs
+++ b/src/strymon_communication/src/rpc.rs
@@ -27,9 +27,40 @@ use message::MessageBuf;
 use serde::ser::Serialize;
 use serde::de::DeserializeOwned;
 
+/// A trait to distinguish remote procedure calls.
+///
+/// #Examples
+/// ```
+/// use strymon_communication::rpc::Name;
+/// #[derive(Clone, Copy)]
+/// #[repr(u8)]
+/// pub enum MyRPC {
+///    UselessCall = 1,
+/// }
+///
+/// impl Name for MyRPC {
+///     type Discriminant = u8;
+///     fn discriminant(&self) -> Self::Discriminant {
+///         *self as Self::Discriminant
+///     }
+///
+///     fn from_discriminant(value: &Self::Discriminant) -> Option<Self> {
+///         match *value {
+///             1 => Some(MyRPC::UselessCall),
+///             _ => None,
+///         }
+///     }
+/// }
+/// ```
 pub trait Name: 'static+Send+Sized {
+
+    /// The discriminant type representing `Self`.
     type Discriminant: 'static+Serialize+DeserializeOwned;
+
+    /// Convert `Self` into a discriminant.
     fn discriminant(&self) -> Self::Discriminant;
+
+    /// Restore `Self` from a discriminant. Returns `None` if `Self` cannot be restored.
     fn from_discriminant(&Self::Discriminant) -> Option<Self>;
 }
 

--- a/src/strymon_communication/src/rpc.rs
+++ b/src/strymon_communication/src/rpc.rs
@@ -29,7 +29,7 @@ use serde::de::DeserializeOwned;
 
 pub trait Name: 'static+Send+Sized {
     type Discriminant: 'static+Serialize+DeserializeOwned;
-    fn discriminant(&self) -> Option<Self::Discriminant>;
+    fn discriminant(&self) -> Self::Discriminant;
     fn from_discriminant(&Self::Discriminant) -> Option<Self>;
 }
 
@@ -165,8 +165,7 @@ impl Outgoing {
         let mut msg = MessageBuf::empty();
         msg.push(Type::Request as u8).unwrap();
         msg.push(id).unwrap();
-        // TODO(moritzho): Figure out how error handling works here
-        msg.push(R::NAME.discriminant().expect("Failed to get discriminant")).unwrap();
+        msg.push(R::NAME.discriminant()).unwrap();
         msg.push::<&R>(r).unwrap();
 
         // step 2: add completion handle for pending responses
@@ -363,7 +362,7 @@ fn _assert() {
     enum E {A}
     impl Name for E {
         type Discriminant = u8;
-        fn discriminant(&self) -> Option<u8> {None}
+        fn discriminant(&self) -> u8 {0}
         fn from_discriminant(_: &u8) -> Option<E> {None}
     }
     fn _is_send<T: Send>() {}

--- a/src/strymon_rpc/Cargo.toml
+++ b/src/strymon_rpc/Cargo.toml
@@ -6,6 +6,8 @@ version = "0.1.1"
 [dependencies]
 serde = "1.0"
 serde_derive = "1.0"
+enum-primitive-derive = "^0.1"
+num-traits = "^0.1"
 
 [dependencies.strymon_communication]
 path = "../strymon_communication/"

--- a/src/strymon_rpc/src/coordinator/mod.rs
+++ b/src/strymon_rpc/src/coordinator/mod.rs
@@ -6,8 +6,37 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use num_traits::{FromPrimitive, ToPrimitive};
+
 use strymon_model::*;
-use strymon_communication::rpc::Request;
+use strymon_communication::rpc::{Name, Request};
+
+#[derive(Primitive, Debug, PartialEq, Eq)]
+pub enum CoordinatorRPC {
+    Submission = 1,
+    Termination = 2,
+    AddExecutor = 3,
+    AddWorkerGroup = 4,
+    Subscribe = 5,
+    Unsubscribe = 6,
+    Publish = 7,
+    Unpublish = 8,
+    Lookup = 9,
+    AddKeeperWorker = 10,
+    GetKeeperAddress = 11,
+    RemoveKeeperWorker = 12,
+}
+
+impl Name for CoordinatorRPC {
+    type Discriminant = u8;
+    fn discriminant(&self) -> Option<Self::Discriminant> {
+        self.to_u8()
+    }
+
+    fn from_discriminant(value: &Self::Discriminant) -> Option<Self> {
+        FromPrimitive::from_u8(*value)
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Placement {
@@ -29,11 +58,11 @@ pub enum SubmissionError {
     SpawnError(::executor::SpawnError),
 }
 
-impl Request<&'static str> for Submission {
+impl Request<CoordinatorRPC> for Submission {
     type Success = QueryId;
     type Error = SubmissionError;
 
-    const NAME: &'static str = "Submission";
+    const NAME: CoordinatorRPC = CoordinatorRPC::Submission;
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -48,11 +77,11 @@ pub enum TerminationError {
     TerminateError(::executor::TerminateError),
 }
 
-impl Request<&'static str> for Termination {
+impl Request<CoordinatorRPC> for Termination {
     type Success = ();
     type Error = TerminationError;
 
-    const NAME: &'static str = "Termination";
+    const NAME: CoordinatorRPC = CoordinatorRPC::Termination;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -65,11 +94,11 @@ pub struct AddExecutor {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ExecutorError;
 
-impl Request<&'static str> for AddExecutor {
+impl Request<CoordinatorRPC> for AddExecutor {
     type Success = ExecutorId;
     type Error = ExecutorError;
 
-    const NAME: &'static str = "AddExecutor";
+    const NAME: CoordinatorRPC = CoordinatorRPC::AddExecutor;
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -91,11 +120,11 @@ pub enum WorkerGroupError {
     PeerFailed,
 }
 
-impl Request<&'static str> for AddWorkerGroup {
+impl Request<CoordinatorRPC> for AddWorkerGroup {
     type Success = QueryToken;
     type Error = WorkerGroupError;
 
-    const NAME: &'static str = "AddWorkerGroup";
+    const NAME: CoordinatorRPC = CoordinatorRPC::AddWorkerGroup;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -111,11 +140,11 @@ pub enum SubscribeError {
     AuthenticationFailure,
 }
 
-impl Request<&'static str> for Subscribe {
+impl Request<CoordinatorRPC> for Subscribe {
     type Success = Topic;
     type Error = SubscribeError;
 
-    const NAME: &'static str = "Subscribe";
+    const NAME: CoordinatorRPC = CoordinatorRPC::Subscribe;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -130,11 +159,11 @@ pub enum UnsubscribeError {
     AuthenticationFailure,
 }
 
-impl Request<&'static str> for Unsubscribe {
+impl Request<CoordinatorRPC> for Unsubscribe {
     type Success = ();
     type Error = UnsubscribeError;
 
-    const NAME: &'static str = "Unsubscribe";
+    const NAME: CoordinatorRPC = CoordinatorRPC::Unsubscribe;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -151,11 +180,11 @@ pub enum PublishError {
     AuthenticationFailure,
 }
 
-impl Request<&'static str> for Publish {
+impl Request<CoordinatorRPC> for Publish {
     type Success = Topic;
     type Error = PublishError;
 
-    const NAME: &'static str = "Publish";
+    const NAME: CoordinatorRPC = CoordinatorRPC::Publish;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -170,11 +199,11 @@ pub enum UnpublishError {
     AuthenticationFailure,
 }
 
-impl Request<&'static str> for Unpublish {
+impl Request<CoordinatorRPC> for Unpublish {
     type Success = ();
     type Error = UnpublishError;
 
-    const NAME: &'static str = "Unpublish";
+    const NAME: CoordinatorRPC = CoordinatorRPC::Unpublish;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -182,11 +211,11 @@ pub struct Lookup {
     pub name: String,
 }
 
-impl Request<&'static str> for Lookup {
+impl Request<CoordinatorRPC> for Lookup {
     type Success = Topic;
     type Error = ();
 
-    const NAME: &'static str = "Lookup";
+    const NAME: CoordinatorRPC = CoordinatorRPC::Lookup;
 }
 
 /// Add a worker of a Keeper.
@@ -202,11 +231,11 @@ pub enum AddKeeperWorkerError {
     WorkerAlreadyExists,
 }
 
-impl Request<&'static str> for AddKeeperWorker {
+impl Request<CoordinatorRPC> for AddKeeperWorker {
     type Success = ();
     type Error = AddKeeperWorkerError;
 
-    const NAME: &'static str = "AddKeeperWorker";
+    const NAME: CoordinatorRPC = CoordinatorRPC::AddKeeperWorker;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -220,11 +249,11 @@ pub enum GetKeeperAddressError {
     KeeperHasNoWorkers,
 }
 
-impl Request<&'static str> for GetKeeperAddress {
+impl Request<CoordinatorRPC> for GetKeeperAddress {
     type Success = (String, u16);
     type Error = GetKeeperAddressError;
 
-    const NAME: &'static str = "GetKeeperAddress";
+    const NAME: CoordinatorRPC = CoordinatorRPC::GetKeeperAddress;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -239,9 +268,9 @@ pub enum RemoveKeeperWorkerError {
     KeeperWorkerDoesntExist,
 }
 
-impl Request<&'static str> for RemoveKeeperWorker {
+impl Request<CoordinatorRPC> for RemoveKeeperWorker {
     type Success = ();
     type Error = RemoveKeeperWorkerError;
 
-    const NAME: &'static str = "RemoveKeeperWorker";
+    const NAME: CoordinatorRPC = CoordinatorRPC::RemoveKeeperWorker;
 }

--- a/src/strymon_rpc/src/coordinator/mod.rs
+++ b/src/strymon_rpc/src/coordinator/mod.rs
@@ -29,7 +29,7 @@ pub enum SubmissionError {
     SpawnError(::executor::SpawnError),
 }
 
-impl Request for Submission {
+impl Request<&'static str> for Submission {
     type Success = QueryId;
     type Error = SubmissionError;
 
@@ -48,7 +48,7 @@ pub enum TerminationError {
     TerminateError(::executor::TerminateError),
 }
 
-impl Request for Termination {
+impl Request<&'static str> for Termination {
     type Success = ();
     type Error = TerminationError;
 
@@ -65,7 +65,7 @@ pub struct AddExecutor {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ExecutorError;
 
-impl Request for AddExecutor {
+impl Request<&'static str> for AddExecutor {
     type Success = ExecutorId;
     type Error = ExecutorError;
 
@@ -91,7 +91,7 @@ pub enum WorkerGroupError {
     PeerFailed,
 }
 
-impl Request for AddWorkerGroup {
+impl Request<&'static str> for AddWorkerGroup {
     type Success = QueryToken;
     type Error = WorkerGroupError;
 
@@ -111,7 +111,7 @@ pub enum SubscribeError {
     AuthenticationFailure,
 }
 
-impl Request for Subscribe {
+impl Request<&'static str> for Subscribe {
     type Success = Topic;
     type Error = SubscribeError;
 
@@ -130,7 +130,7 @@ pub enum UnsubscribeError {
     AuthenticationFailure,
 }
 
-impl Request for Unsubscribe {
+impl Request<&'static str> for Unsubscribe {
     type Success = ();
     type Error = UnsubscribeError;
 
@@ -151,7 +151,7 @@ pub enum PublishError {
     AuthenticationFailure,
 }
 
-impl Request for Publish {
+impl Request<&'static str> for Publish {
     type Success = Topic;
     type Error = PublishError;
 
@@ -170,7 +170,7 @@ pub enum UnpublishError {
     AuthenticationFailure,
 }
 
-impl Request for Unpublish {
+impl Request<&'static str> for Unpublish {
     type Success = ();
     type Error = UnpublishError;
 
@@ -182,7 +182,7 @@ pub struct Lookup {
     pub name: String,
 }
 
-impl Request for Lookup {
+impl Request<&'static str> for Lookup {
     type Success = Topic;
     type Error = ();
 
@@ -202,7 +202,7 @@ pub enum AddKeeperWorkerError {
     WorkerAlreadyExists,
 }
 
-impl Request for AddKeeperWorker {
+impl Request<&'static str> for AddKeeperWorker {
     type Success = ();
     type Error = AddKeeperWorkerError;
 
@@ -220,7 +220,7 @@ pub enum GetKeeperAddressError {
     KeeperHasNoWorkers,
 }
 
-impl Request for GetKeeperAddress {
+impl Request<&'static str> for GetKeeperAddress {
     type Success = (String, u16);
     type Error = GetKeeperAddressError;
 
@@ -239,7 +239,7 @@ pub enum RemoveKeeperWorkerError {
     KeeperWorkerDoesntExist,
 }
 
-impl Request for RemoveKeeperWorker {
+impl Request<&'static str> for RemoveKeeperWorker {
     type Success = ();
     type Error = RemoveKeeperWorkerError;
 

--- a/src/strymon_rpc/src/coordinator/mod.rs
+++ b/src/strymon_rpc/src/coordinator/mod.rs
@@ -6,12 +6,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use num_traits::{FromPrimitive, ToPrimitive};
+use num_traits::FromPrimitive;
 
 use strymon_model::*;
 use strymon_communication::rpc::{Name, Request};
 
-#[derive(Primitive, Debug, PartialEq, Eq)]
+#[derive(Primitive, Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u8)]
 pub enum CoordinatorRPC {
     Submission = 1,
     Termination = 2,
@@ -29,8 +30,8 @@ pub enum CoordinatorRPC {
 
 impl Name for CoordinatorRPC {
     type Discriminant = u8;
-    fn discriminant(&self) -> Option<Self::Discriminant> {
-        self.to_u8()
+    fn discriminant(&self) -> Self::Discriminant {
+        *self as Self::Discriminant
     }
 
     fn from_discriminant(value: &Self::Discriminant) -> Option<Self> {

--- a/src/strymon_rpc/src/executor/mod.rs
+++ b/src/strymon_rpc/src/executor/mod.rs
@@ -6,12 +6,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use num_traits::{FromPrimitive, ToPrimitive};
+use num_traits::FromPrimitive;
 
 use strymon_model::*;
 use strymon_communication::rpc::{Name, Request};
 
-#[derive(Primitive, Debug, PartialEq, Eq)]
+#[derive(Primitive, Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u8)]
 pub enum ExecutorRPC {
     SpawnQuery = 1,
     TerminateQuery = 2,
@@ -20,8 +21,8 @@ pub enum ExecutorRPC {
 impl Name for ExecutorRPC {
     type Discriminant = u8;
 
-    fn discriminant(&self) -> Option<Self::Discriminant> {
-        self.to_u8()
+    fn discriminant(&self) -> Self::Discriminant {
+        *self as Self::Discriminant
     }
 
     fn from_discriminant(value: &Self::Discriminant) -> Option<Self> {

--- a/src/strymon_rpc/src/executor/mod.rs
+++ b/src/strymon_rpc/src/executor/mod.rs
@@ -24,7 +24,7 @@ pub enum SpawnError {
     ExecFailed,
 }
 
-impl Request for SpawnQuery {
+impl Request<&'static str> for SpawnQuery {
     type Success = ();
     type Error = SpawnError;
 
@@ -42,7 +42,7 @@ pub enum TerminateError {
     OperationNotSupported,
 }
 
-impl Request for TerminateQuery {
+impl Request<&'static str> for TerminateQuery {
     type Success = ();
     type Error = TerminateError;
 

--- a/src/strymon_rpc/src/executor/mod.rs
+++ b/src/strymon_rpc/src/executor/mod.rs
@@ -6,8 +6,28 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use num_traits::{FromPrimitive, ToPrimitive};
+
 use strymon_model::*;
-use strymon_communication::rpc::Request;
+use strymon_communication::rpc::{Name, Request};
+
+#[derive(Primitive, Debug, PartialEq, Eq)]
+pub enum ExecutorRPC {
+    SpawnQuery = 1,
+    TerminateQuery = 2,
+}
+
+impl Name for ExecutorRPC {
+    type Discriminant = u8;
+
+    fn discriminant(&self) -> Option<Self::Discriminant> {
+        self.to_u8()
+    }
+
+    fn from_discriminant(value: &Self::Discriminant) -> Option<Self> {
+        FromPrimitive::from_u8(*value)
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SpawnQuery {
@@ -24,11 +44,11 @@ pub enum SpawnError {
     ExecFailed,
 }
 
-impl Request<&'static str> for SpawnQuery {
+impl Request<ExecutorRPC> for SpawnQuery {
     type Success = ();
     type Error = SpawnError;
 
-    const NAME: &'static str = "SpawnQuery";
+    const NAME: ExecutorRPC = ExecutorRPC::SpawnQuery;
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -42,9 +62,9 @@ pub enum TerminateError {
     OperationNotSupported,
 }
 
-impl Request<&'static str> for TerminateQuery {
+impl Request<ExecutorRPC> for TerminateQuery {
     type Success = ();
     type Error = TerminateError;
 
-    const NAME: &'static str = "TerminateQuery";
+    const NAME: ExecutorRPC = ExecutorRPC::TerminateQuery;
 }

--- a/src/strymon_rpc/src/lib.rs
+++ b/src/strymon_rpc/src/lib.rs
@@ -6,6 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[macro_use]
+extern crate enum_primitive_derive;
+extern crate num_traits;
+
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;

--- a/src/strymon_runtime/src/coordinator/dispatch.rs
+++ b/src/strymon_runtime/src/coordinator/dispatch.rs
@@ -32,9 +32,9 @@ impl Dispatch {
         }
     }
 
-    pub fn dispatch(&mut self, req: RequestBuf) -> Result<(), Error> {
+    pub fn dispatch<'a>(&'a mut self, req: RequestBuf<&'static str>) -> Result<(), Error> {
         debug!("dispatching request {}", req.name());
-        match req.name() {
+        match *req.name() {
             Submission::NAME => {
                 let (req, resp) = req.decode::<Submission>()?;
                 let submission = self.coord

--- a/src/strymon_runtime/src/coordinator/dispatch.rs
+++ b/src/strymon_runtime/src/coordinator/dispatch.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::io::{Error, ErrorKind};
+use std::io::Error;
 
 use futures::future::Future;
 use tokio_core::reactor::Handle;
@@ -32,8 +32,8 @@ impl Dispatch {
         }
     }
 
-    pub fn dispatch<'a>(&'a mut self, req: RequestBuf<&'static str>) -> Result<(), Error> {
-        debug!("dispatching request {}", req.name());
+    pub fn dispatch<'a>(&'a mut self, req: RequestBuf<CoordinatorRPC>) -> Result<(), Error> {
+        debug!("dispatching request {:?}", req.name());
         match *req.name() {
             Submission::NAME => {
                 let (req, resp) = req.decode::<Submission>()?;
@@ -100,10 +100,6 @@ impl Dispatch {
                 let (RemoveKeeperWorker { name, worker_num }, resp) =
                     req.decode::<RemoveKeeperWorker>()?;
                 resp.respond(self.coord.remove_keeper_worker(name, worker_num));
-            }
-            _ => {
-                let err = Error::new(ErrorKind::InvalidData, "invalid request");
-                return Err(err);
             }
         }
 

--- a/src/strymon_runtime/src/coordinator/handler.rs
+++ b/src/strymon_runtime/src/coordinator/handler.rs
@@ -56,12 +56,12 @@ impl ExecutorState {
         self.ports.push_back(port);
     }
 
-    fn spawn(&self, req: &SpawnQuery) -> Response<SpawnQuery> {
+    fn spawn(&self, req: &SpawnQuery) -> Response<&'static str, SpawnQuery> {
         debug!("issue spawn request {:?}", req);
         self.tx.request(req)
     }
 
-    fn terminate(&self, job_id: QueryId) -> Response<TerminateQuery> {
+    fn terminate(&self, job_id: QueryId) -> Response<&'static str, TerminateQuery> {
         self.tx.request(&TerminateQuery { query: job_id })
     }
 }

--- a/src/strymon_runtime/src/coordinator/handler.rs
+++ b/src/strymon_runtime/src/coordinator/handler.rs
@@ -56,12 +56,12 @@ impl ExecutorState {
         self.ports.push_back(port);
     }
 
-    fn spawn(&self, req: &SpawnQuery) -> Response<&'static str, SpawnQuery> {
+    fn spawn(&self, req: &SpawnQuery) -> Response<ExecutorRPC, SpawnQuery> {
         debug!("issue spawn request {:?}", req);
         self.tx.request(req)
     }
 
-    fn terminate(&self, job_id: QueryId) -> Response<&'static str, TerminateQuery> {
+    fn terminate(&self, job_id: QueryId) -> Response<ExecutorRPC, TerminateQuery> {
         self.tx.request(&TerminateQuery { query: job_id })
     }
 }

--- a/src/strymon_runtime/src/coordinator/mod.rs
+++ b/src/strymon_runtime/src/coordinator/mod.rs
@@ -49,7 +49,7 @@ impl Default for Builder {
 impl Builder {
     pub fn run(self) -> Result<()> {
         let network = Network::init()?;
-        let server = network.server(self.port)?;
+        let server = network.server::<&'static str, _>(self.port)?;
 
         let mut core = Core::new()?;
         let handle = core.handle();

--- a/src/strymon_runtime/src/coordinator/mod.rs
+++ b/src/strymon_runtime/src/coordinator/mod.rs
@@ -16,6 +16,8 @@ use tokio_core::reactor::Core;
 
 use strymon_communication::Network;
 
+use strymon_rpc::coordinator::CoordinatorRPC;
+
 use self::handler::Coordinator;
 use self::dispatch::Dispatch;
 use self::catalog::Catalog;
@@ -49,7 +51,7 @@ impl Default for Builder {
 impl Builder {
     pub fn run(self) -> Result<()> {
         let network = Network::init()?;
-        let server = network.server::<&'static str, _>(self.port)?;
+        let server = network.server::<CoordinatorRPC, _>(self.port)?;
 
         let mut core = Core::new()?;
         let handle = core.handle();

--- a/src/strymon_runtime/src/executor/mod.rs
+++ b/src/strymon_runtime/src/executor/mod.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use std::fs;
-use std::io::{Error, ErrorKind};
+use std::io::Error;
 use std::env;
 use std::path::PathBuf;
 use std::ffi::OsStr;
@@ -104,7 +104,7 @@ impl ExecutorService {
         self.process.spawn(id, exec)
     }
 
-    pub fn dispatch(&mut self, req: RequestBuf<&'static str>) -> Result<(), Error> {
+    pub fn dispatch(&mut self, req: RequestBuf<ExecutorRPC>) -> Result<(), Error> {
         match *req.name() {
             SpawnQuery::NAME => {
                 let (SpawnQuery { query, hostlist }, resp) = req.decode::<SpawnQuery>()?;
@@ -117,10 +117,6 @@ impl ExecutorService {
                 debug!("termination request for {:?}", query);
                 resp.respond(self.process.terminate(query));
                 Ok(())
-            }
-            _ => {
-                let err = Error::new(ErrorKind::InvalidData, "invalid request");
-                return Err(err);
             }
         }
     }
@@ -182,7 +178,7 @@ impl Builder {
         let Builder { ports, coord, workdir } = self;
         let network = Network::init()?;
         let host = network.hostname();
-        let (tx, rx) = network.client::<&'static str, _>(&*coord)?;
+        let (tx, rx) = network.client::<ExecutorRPC, _>(&*coord)?;
 
         let mut core = Core::new()?;
         let handle = core.handle();

--- a/src/strymon_runtime/src/executor/mod.rs
+++ b/src/strymon_runtime/src/executor/mod.rs
@@ -104,8 +104,8 @@ impl ExecutorService {
         self.process.spawn(id, exec)
     }
 
-    pub fn dispatch(&mut self, req: RequestBuf) -> Result<(), Error> {
-        match req.name() {
+    pub fn dispatch(&mut self, req: RequestBuf<&'static str>) -> Result<(), Error> {
+        match *req.name() {
             SpawnQuery::NAME => {
                 let (SpawnQuery { query, hostlist }, resp) = req.decode::<SpawnQuery>()?;
                 debug!("spawn request for {:?}", query);
@@ -182,7 +182,7 @@ impl Builder {
         let Builder { ports, coord, workdir } = self;
         let network = Network::init()?;
         let host = network.hostname();
-        let (tx, rx) = network.client(&*coord)?;
+        let (tx, rx) = network.client::<&'static str, _>(&*coord)?;
 
         let mut core = Core::new()?;
         let handle = core.handle();

--- a/src/strymon_runtime/src/query/mod.rs
+++ b/src/strymon_runtime/src/query/mod.rs
@@ -28,7 +28,7 @@ use strymon_communication::rpc::Outgoing;
 
 use executor::executable::NativeExecutable;
 use strymon_model::QueryId;
-use strymon_rpc::coordinator::{AddWorkerGroup, QueryToken};
+use strymon_rpc::coordinator::{CoordinatorRPC, AddWorkerGroup, QueryToken};
 
 pub mod subscribe;
 pub mod publish;
@@ -46,7 +46,7 @@ fn initialize(id: QueryId,
               coord: String)
               -> Result<Coordinator, IoError> {
     let network = Network::init()?;
-    let (tx, _) = network.client::<&'static str, _>(&*coord)?;
+    let (tx, _) = network.client::<CoordinatorRPC, _>(&*coord)?;
 
     let announce = tx.request(&AddWorkerGroup {
         query: id,

--- a/src/strymon_runtime/src/query/mod.rs
+++ b/src/strymon_runtime/src/query/mod.rs
@@ -46,7 +46,7 @@ fn initialize(id: QueryId,
               coord: String)
               -> Result<Coordinator, IoError> {
     let network = Network::init()?;
-    let (tx, _) = network.client(&*coord)?;
+    let (tx, _) = network.client::<&'static str, _>(&*coord)?;
 
     let announce = tx.request(&AddWorkerGroup {
         query: id,

--- a/src/strymon_runtime/src/submit/mod.rs
+++ b/src/strymon_runtime/src/submit/mod.rs
@@ -32,7 +32,7 @@ pub struct Submitter {
 
 impl Submitter {
     pub fn new<E: ToSocketAddrs>(network: &Network, addr: E) -> Result<Self> {
-        let (tx, _) = network.client::<&'static str, _>(addr)?;
+        let (tx, _) = network.client::<CoordinatorRPC, _>(addr)?;
         Ok(Submitter {
             tx: tx,
             network: network.clone(),
@@ -43,7 +43,7 @@ impl Submitter {
                      query: QueryProgram,
                      name: N,
                      placement: Placement)
-                     -> Response<&'static str, Submission>
+                     -> Response<CoordinatorRPC, Submission>
         where N: Into<Option<String>>
     {
         let submission = Submission {
@@ -55,7 +55,7 @@ impl Submitter {
         self.tx.request(&submission)
     }
 
-    pub fn terminate(&self, id: QueryId) -> Response<&'static str, Termination> {
+    pub fn terminate(&self, id: QueryId) -> Response<CoordinatorRPC, Termination> {
         let termination = Termination {
             query: id,
         };

--- a/src/strymon_runtime/src/submit/mod.rs
+++ b/src/strymon_runtime/src/submit/mod.rs
@@ -32,7 +32,7 @@ pub struct Submitter {
 
 impl Submitter {
     pub fn new<E: ToSocketAddrs>(network: &Network, addr: E) -> Result<Self> {
-        let (tx, _) = network.client(addr)?;
+        let (tx, _) = network.client::<&'static str, _>(addr)?;
         Ok(Submitter {
             tx: tx,
             network: network.clone(),
@@ -43,7 +43,7 @@ impl Submitter {
                      query: QueryProgram,
                      name: N,
                      placement: Placement)
-                     -> Response<Submission>
+                     -> Response<&'static str, Submission>
         where N: Into<Option<String>>
     {
         let submission = Submission {
@@ -55,7 +55,7 @@ impl Submitter {
         self.tx.request(&submission)
     }
 
-    pub fn terminate(&self, id: QueryId) -> Response<Termination> {
+    pub fn terminate(&self, id: QueryId) -> Response<&'static str, Termination> {
         let termination = Termination {
             query: id,
         };


### PR DESCRIPTION
This PR changes the `Request`/`Response` traits to have a generic type that refers to the multiplexing key. That way implementations can chose what kind of type they want to use to distinguish different RPC requests.

I'm not completely sure this is the proper way of implementing the functionality. The original code was working under the assumption that `String` can be used to match `&'static str`, which works but cannot easily be generalized. Now, it makes sure that `&'static str` is used consistently everywhere. However, this might be what we really want.

Signed-off-by: Moritz Hoffmann <moritz.hoffmann@inf.ethz.ch>