### PR TITLE
scripts: Properly canonicalize paths, add support for workdir

### DIFF
--- a/bin/start-strymon.sh
+++ b/bin/start-strymon.sh
@@ -53,10 +53,10 @@ parse_args "$@"
 shift $((OPTIND-1))
 
 # ensure paths are absolute
-LOGDIR="$(abspath "${LOGDIR}")"
-WORKDIR="$(abspath "${WORKDIR}")"
+LOGDIR="$(canonicalize_path "${LOGDIR}")"
+WORKDIR="$(canonicalize_path "${WORKDIR}")"
 BINARY="$(locate_binary)"
-FULL_BINARY="$(abspath "${BINARY}")"
+FULL_BINARY="$(canonicalize_path "${BINARY}")"
 
 # create working directory and spawn cluster
 mkdir -p "${LOGDIR}"

--- a/bin/stop-strymon.sh
+++ b/bin/stop-strymon.sh
@@ -11,7 +11,7 @@ parse_args "$@"
 shift $((OPTIND-1))
 
 # ensure paths are absolute
-LOGDIR="$(abspath "${LOGDIR}")"
+LOGDIR="$(canonicalize_path "${LOGDIR}")"
 
 # extract coordinator hostname
 case "${COORDINATOR}" in


### PR DESCRIPTION
`canonicalize_path` is basically `readlink -f`, without symlink resolution, but support for macOS.