### PR TITLE
strymon_communication: #![deny(missing_docs)]

### DIFF
--- a/src/strymon_communication/Cargo.toml
+++ b/src/strymon_communication/Cargo.toml
@@ -10,3 +10,6 @@ serde = "1.0"
 rmp-serde = "0.13"
 futures = "0.1"
 log = "0.4"
+
+[dev-dependencies]
+serde_derive = "1.0"

--- a/src/strymon_communication/src/fetch.rs
+++ b/src/strymon_communication/src/fetch.rs
@@ -6,6 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! Utilities for sending files over the network.
+//!
+//! Currently implements a primitive server which copies the raw file contents to
+//! any client which connects to the socket.
+
 use std::net::{TcpListener, TcpStream};
 use std::io::{copy, Result, Error, ErrorKind};
 use std::fs::{self, File};
@@ -14,12 +19,14 @@ use std::thread;
 
 use Network;
 
+/// Handle for the file server. Closes the server when dropped.
 pub struct Handle {
     url: String,
     listener: TcpListener,
 }
 
 impl Handle {
+    /// Returns a URL in the format of `tcp://host:port` for the given upload.
     pub fn url(&self) -> String {
         self.url.clone()
     }
@@ -45,6 +52,7 @@ fn fix_permissions<P: AsRef<Path>>(path: P) -> Result<()> {
 fn fix_permissions<P: AsRef<Path>>(_: P) -> Result<()> { Ok(()) }
 
 impl Network {
+    /// Serves the specified file on a ephemerial network port.
     pub fn upload<P: AsRef<Path>>(&self, path: P) -> Result<Handle> {
         let path = path.as_ref().to_owned();
         if !path.is_file() {
@@ -72,6 +80,7 @@ impl Network {
         })
     }
 
+    /// Downloads the file served at `url` and downloads it into `path`.
     pub fn download<P: AsRef<Path>>(&self, url: &str, path: P) -> Result<()> {
         // url should have the format: "tcp://host:port"
         if !url.starts_with("tcp://") {

--- a/src/strymon_communication/src/lib.rs
+++ b/src/strymon_communication/src/lib.rs
@@ -6,6 +6,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![deny(missing_docs)]
+
+//! Communication primitives for Strymon.
+//!
+//! This crate contains the networking primitives for Strymon. It provides
+//! three different abstraction layers:
+//!
+//!   - [`message`](message/index.html): A frame-delimited multi-part message format.
+//!   - [`transport`](transport/index.html): Bi-directional asynchronous message channels,
+//!     for sending untyped [`MessageBuf`](message/struct.MessageBuf.html)s across the network.
+//!   - [`rpc`](rpc/index.html): Semi-typed asynchronous, multiplexed request-response channels.
+//!
+//! In order to use the networking functionality, client code must initialize a
+//! [`Network`](struct.Network.html) handle first.
+
+
 extern crate bytes;
 extern crate byteorder;
 
@@ -16,44 +32,22 @@ extern crate futures;
 
 #[macro_use] extern crate log;
 
-use std::io;
-use std::env;
-use std::sync::Arc;
+mod network;
 
 pub mod transport;
 pub mod message;
-pub mod fetch;
 pub mod rpc;
+pub mod fetch;
 
+use std::sync::Arc;
+
+/// Handle to the networking subsystem.
+///
+/// Currently, this handle only stores information about the externally reachable
+/// hostname of the current process. In the future, it might be backed by a
+/// dedicated networking thread to implement its methods. Thus it recommended to
+/// only initialize it once per process.
 #[derive(Clone, Debug)]
 pub struct Network {
     hostname: Arc<String>,
-}
-
-impl Network {
-    pub fn init() -> io::Result<Self> {
-        // try to guess external hostname
-        let hostname = if let Ok(hostname) = env::var("TIMELY_SYSTEM_HOSTNAME") {
-            hostname
-        } else {
-            warn!("unable to retrieve external hostname of machine.");
-            warn!("falling back to 'localhost', set TIMELY_SYSTEM_HOSTNAME to override");
-
-            String::from("localhost")
-        };
-
-        Ok(Network {
-            hostname: Arc::new(hostname),
-        })
-    }
-
-    pub fn with_hostname(hostname: String) -> io::Result<Self> {
-        Ok(Network {
-            hostname: Arc::new(hostname),
-        })
-    }
-
-    pub fn hostname(&self) -> String {
-        (*self.hostname).clone()
-    }
 }

--- a/src/strymon_communication/src/network.rs
+++ b/src/strymon_communication/src/network.rs
@@ -1,0 +1,51 @@
+// Copyright 2018 ETH Zurich. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Network type.
+//  This is in its own module so that rustdoc renders its methods first.
+
+use std::io;
+use std::env;
+use std::sync::Arc;
+
+use Network;
+
+impl Network {
+    /// Creates a new default network handle.
+    ///
+    /// This will try to use the externally reachable hostname of the current
+    /// process by reading the `STRYMON_COMM_HOSTNAME` environment variable. It will
+    /// fall-back to `"localhost"` if the environment variable is not available.
+    pub fn init() -> io::Result<Self> {
+        // try to guess external hostname
+        let hostname = if let Ok(hostname) = env::var("TIMELY_SYSTEM_HOSTNAME") {
+            hostname
+        } else if let Ok(hostname) = env::var("STRYMON_COMM_HOSTNAME") {
+            hostname
+        } else {
+            warn!("unable to retrieve external hostname of machine.");
+            warn!("falling back to 'localhost', set TIMELY_SYSTEM_HOSTNAME to override");
+
+            String::from("localhost")
+        };
+
+        Network::with_hostname(hostname)
+    }
+
+    /// Creates a new instance with a set externally reachable hostname.
+    pub fn with_hostname(hostname: String) -> io::Result<Self> {
+        Ok(Network {
+            hostname: Arc::new(hostname),
+        })
+    }
+
+    /// Returns the configured externally reachable hostname of the current process.
+    pub fn hostname(&self) -> String {
+        (*self.hostname).clone()
+    }
+}

--- a/src/strymon_communication/tests/calc.rs
+++ b/src/strymon_communication/tests/calc.rs
@@ -1,0 +1,144 @@
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate strymon_communication;
+extern crate futures;
+
+use std::io;
+use std::thread;
+
+use futures::prelude::*;
+
+use strymon_communication::Network;
+use strymon_communication::rpc::*;
+
+// A service with the methods `Subtract` and `Divide`.
+#[derive(Clone, Copy)]
+pub enum CalcRPC {
+   Subtract,
+   Divide,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SubtractArgs {
+    pub minuend: i32,
+    pub subtrahend: i32,
+}
+
+impl Request<CalcRPC> for SubtractArgs {
+    const NAME: CalcRPC = CalcRPC::Subtract;
+    type Success = i32; // difference
+    type Error = ();    // cannot fail
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DivideArgs {
+    pub dividend: i32,
+    pub divisor: i32,
+}
+
+// TODO(swicki): because of https://github.com/3Hren/msgpack-rust/issues/159,
+// we currently cannot use a unit struct here.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum DivideError {
+    DivisionByZero
+}
+
+impl Request<CalcRPC> for DivideArgs {
+    const NAME: CalcRPC = CalcRPC::Divide;
+    type Success = i32; // quotient
+    type Error = DivideError;
+}
+
+impl Name for CalcRPC {
+    type Discriminant = u8;
+
+    fn discriminant(&self) -> Self::Discriminant {
+        match *self {
+            CalcRPC::Subtract => 1,
+            CalcRPC::Divide => 2,
+        }
+    }
+
+    fn from_discriminant(value: &Self::Discriminant) -> Option<Self> {
+        match *value {
+            1 => Some(CalcRPC::Subtract),
+            2 => Some(CalcRPC::Divide),
+            _ => None,
+        }
+    }
+}
+
+fn serve_client(incoming: Incoming<CalcRPC>) -> io::Result<()> {
+    for request in incoming.wait() {
+        let request = request?;
+        match request.name() {
+            &CalcRPC::Subtract => {
+                let (args, resp) = request.decode::<SubtractArgs>()?;
+                let result = Ok(args.minuend - args.subtrahend);
+                resp.respond(result)
+            },
+            &CalcRPC::Divide => {
+                let (args, resp) = request.decode::<DivideArgs>()?;
+                let result = if args.divisor == 0 {
+                    Err(DivideError::DivisionByZero)
+                } else {
+                    Ok(args.dividend / args.divisor)
+                };
+                resp.respond(result)
+            }
+        };
+    }
+
+    Ok(())
+}
+
+/// Spawns a server in a new thread and returns its local port
+fn calc_server(network: &Network) -> io::Result<u16> {
+    let server = network.server::<CalcRPC, _>(None)?;
+    let (_, port) = server.external_addr();
+    thread::spawn(|| {
+        let mut clients = server.wait();
+        // this server is acting as a receiver only
+        while let Some(Ok((_, rx))) = clients.next() {
+            thread::spawn(move || {
+                serve_client(rx).expect("failed to serve client")
+            });
+        }
+    });
+
+    Ok(port)
+}
+
+fn run_client() -> io::Result<()> {
+    let network = Network::with_hostname(String::from("localhost"))?;
+    let port = calc_server(&network)?;
+
+    // this client only acts as a sender
+    let (tx, _) = network.client::<CalcRPC, _>(("localhost", port))?;
+
+    let ten_minus_one = tx.request(&SubtractArgs {
+        minuend: 10,
+        subtrahend: 1,
+    }).wait_unwrap();
+    assert_eq!(ten_minus_one, Ok(9));
+
+    let twenty_divided_by_five = tx.request(&DivideArgs {
+        dividend: 20,
+        divisor: 5,
+    }).wait_unwrap();
+    assert_eq!(twenty_divided_by_five, Ok(4));
+
+    let division_by_zero = tx.request(&DivideArgs {
+        dividend: 100,
+        divisor: 0,
+    }).wait_unwrap();
+    assert_eq!(division_by_zero, Err(DivideError::DivisionByZero));
+
+    Ok(())
+}
+
+#[test]
+fn rpc_calculator() {
+    run_client().expect("I/O failure")
+}


### PR DESCRIPTION
This adds some basic documentation for the `strymon_communication` crate and introduces the `#![deny(missing_docs)]` attribute, asserting that all public methods and types within that crate must be documented.