### PR TITLE
 Introduce a new "Service" topic type 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,8 +477,13 @@ dependencies = [
 name = "simple-pubsub"
 version = "0.1.0"
 dependencies = [
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strymon_communication 0.1.2",
  "strymon_job 0.1.2",
  "timely 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typename 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/strymon_job/src/lib.rs
+++ b/src/strymon_job/src/lib.rs
@@ -56,6 +56,7 @@ extern crate strymon_rpc;
 mod protocol;
 mod publisher;
 mod subscriber;
+mod util;
 pub mod operators;
 
 use std::io;

--- a/src/strymon_job/src/operators/mod.rs
+++ b/src/strymon_job/src/operators/mod.rs
@@ -4,3 +4,4 @@ pub use protocol::RemoteTimestamp;
 
 pub mod publish;
 pub mod subscribe;
+pub mod service;

--- a/src/strymon_job/src/operators/publish.rs
+++ b/src/strymon_job/src/operators/publish.rs
@@ -146,7 +146,7 @@ impl<T, D> Drop for Publication<T, D> {
 
 impl Coordinator {
     /// Submit a publication request to the coordinator and block.
-    fn publish_request(&self,
+    pub(crate) fn publish_request(&self,
                        name: String,
                        schema: TopicSchema,
                        addr: (String, u16))
@@ -215,7 +215,7 @@ impl Coordinator {
     }
 
     /// Submits a depublication request.
-    fn unpublish(&self, topic: TopicId) -> Result<(), PublicationError> {
+    pub(crate) fn unpublish(&self, topic: TopicId) -> Result<(), PublicationError> {
         self.tx
             .request(&Unpublish {
                 topic: topic,

--- a/src/strymon_job/src/operators/service.rs
+++ b/src/strymon_job/src/operators/service.rs
@@ -1,0 +1,138 @@
+// Copyright 2018 ETH Zurich. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Types used to announce and find services announced in the catalog.
+
+use std::io;
+use std::marker::PhantomData;
+
+use typename::TypeName;
+use futures::{Async, Poll};
+use futures::stream::Stream;
+
+use strymon_model::{Topic, TopicType, TopicSchema};
+use strymon_communication::rpc::*;
+
+use Coordinator;
+use super::publish::PublicationError;
+use super::subscribe::SubscriptionError;
+use util::StreamsUnordered;
+
+/// A source of incoming requests.
+///
+/// Will deregister the announced service from the catalog when dropped.
+pub struct Service<N: Name> {
+    server: Server<N>,
+    clients: StreamsUnordered<Incoming<N>>,
+    topic: Topic,
+    coord: Coordinator,
+}
+
+impl<N: Name> Drop for Service<N> {
+    fn drop(&mut self) {
+        if let Err(err) = self.coord.unpublish(self.topic.id) {
+            warn!("failed to unpublish service: {:?}", err)
+        }
+    }
+}
+
+impl<N: Name> Stream for Service<N> {
+    type Item = RequestBuf<N>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        // make sure to accept any new incoming clients first
+        while let Async::Ready(Some((_, client))) = self.server.poll()? {
+            self.clients.push(client);
+        }
+
+        self.clients.poll()
+    }
+}
+
+/// Client handle for sending requests to a announced service.
+///
+/// Will deregister the announced service from the catalog when dropped.
+pub struct Client<N: Name> {
+    queue: Outgoing,
+    topic: Topic,
+    coord: Coordinator,
+    name: PhantomData<N>,
+}
+
+impl<N: Name> Client<N> {
+    /// Asynchronously sends out a request to the remote peer.
+    ///
+    /// Returns a future for the pending response. The next request can be
+    /// submitted without having to wait for the previous response to arrive.
+    pub fn request<R: Request<N>>(&self, r: &R) -> Response<N, R> {
+        self.queue.request(r)
+    }
+}
+
+impl<N: Name> Drop for Client<N> {
+    fn drop(&mut self) {
+        if let Err(err) = self.coord.unsubscribe(self.topic.id) {
+            warn!("failed to unpublish service: {:?}", err)
+        }
+    }
+}
+
+impl Coordinator {
+    /// Creates a new request service and announces it in the catalog.
+    ///
+    /// Given a service interface definition and a name, creates a new server
+    /// for receiving incoming requests. A topic is created under the specified
+    /// name which is used by clients to bind to the service.
+    pub fn announce_service<N: Name + TypeName>(&self, name: &str)
+        -> Result<Service<N>, PublicationError>
+    {
+        // create a new service and obtain its address
+        let server = self.network.server(None)?;
+        let addr = {
+            let (host, port) = server.external_addr();
+            (host.to_string(), port)
+        };
+
+        // announce the service to the coordinator
+        let schema = TopicSchema::Service(TopicType::of::<N>());
+        let topic = self.publish_request(name.to_string(), schema, addr)?;
+        let clients = StreamsUnordered::new();
+        let coord = self.clone();
+        Ok(Service { server, clients, topic, coord })
+    }
+
+    /// Creates a binding to a service topic for sending requests.
+    ///
+    /// Returns a handle for submitting requests to the given server. The
+    /// binding created by this invocation is also stored in the catalog as
+    /// a `Subscription`. The subscription is revoked once the `Client` handle
+    /// is dropped.
+    ///
+    /// When `blocking` is true, this call blocks until a remote job registers
+    /// a service with the matching name. If `blocking` is false, the call
+    /// returns with an error if the topic does not exist.
+    pub fn bind_service<N: Name + TypeName>(&self, name: &str, blocking: bool)
+        -> Result<Client<N>, SubscriptionError>
+    {
+        let topic = self.subscribe_request(name, blocking)?;
+        let schema = TopicSchema::Service(TopicType::of::<N>());
+        if topic.schema != schema {
+            return Err(SubscriptionError::TypeMismatch)
+        }
+
+        let queue = {
+            let addr = (&*topic.addr.0, topic.addr.1);
+            let (tx, _) = self.network.client::<N, _>(addr)?;
+            tx
+        };
+        let coord = self.clone();
+        let name = PhantomData;
+        Ok(Client { queue, topic, coord, name })
+    }
+}

--- a/src/strymon_job/src/operators/subscribe.rs
+++ b/src/strymon_job/src/operators/subscribe.rs
@@ -147,11 +147,23 @@ impl<T, E> From<Result<T, E>> for SubscriptionError
 
 impl Coordinator {
     /// Unsubscribes from a topic.
-    fn unsubscribe(&self, topic: TopicId) -> Result<(), SubscriptionError> {
+    pub(crate) fn unsubscribe(&self, topic: TopicId) -> Result<(), SubscriptionError> {
         self.tx
             .request(&Unsubscribe {
                 topic: topic,
                 token: self.token,
+            })
+            .map_err(SubscriptionError::from)
+            .wait()
+    }
+
+
+    pub(crate) fn subscribe_request(&self, name: &str, blocking: bool) -> Result<Topic, SubscriptionError> {
+        self.tx
+            .request(&Subscribe {
+                name: name.to_string(),
+                token: self.token,
+                blocking: blocking,
             })
             .map_err(SubscriptionError::from)
             .wait()

--- a/src/strymon_job/src/util.rs
+++ b/src/strymon_job/src/util.rs
@@ -1,0 +1,57 @@
+use futures::{Async, Poll};
+use futures::stream::{Stream, StreamFuture, FuturesUnordered};
+
+/// A merged set of streams. Similar to `FuturesUnordered`, but for homogenious
+/// streams.
+pub struct StreamsUnordered<S> {
+    inner: FuturesUnordered<StreamFuture<S>>,
+}
+
+impl<S: Stream> StreamsUnordered<S> {
+    /// Creates an empty polling set.
+    pub fn new() -> Self {
+        StreamsUnordered {
+            inner: FuturesUnordered::new(),
+        }
+    }
+
+    /// Adds a stream to the polling set.
+    pub fn push(&mut self, stream: S) {
+        self.inner.push(stream.into_future())
+    }
+}
+
+impl<S: Stream> Stream for StreamsUnordered<S> {
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        loop {
+            match self.inner.poll() {
+                Ok(Async::Ready(Some((Some(val), stream)))) => {
+                    // stream returned a value, reregister and yield value
+                    self.push(stream);
+                    return Ok(Async::Ready(Some(val)));
+                },
+                Ok(Async::Ready(Some((None, stream)))) => {
+                    // stream exhausted, drop it and try next one
+                    drop(stream);
+                    continue;
+                }
+                Ok(Async::Ready(None)) => {
+                    // all streams exhausted
+                    return Ok(Async::Ready(None));
+                }
+                Ok(Async::NotReady) => {
+                    // all streams busy
+                    return Ok(Async::NotReady);
+                }
+                Err((err, stream)) => {
+                    // stream returned an error, reregister and yield error
+                    self.push(stream);
+                    return Err(err);
+                },
+            }
+        }
+    }
+}

--- a/src/strymon_model/src/lib.rs
+++ b/src/strymon_model/src/lib.rs
@@ -48,6 +48,7 @@ impl TopicType {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Abomonation, TypeName)]
 pub enum TopicSchema {
     Collection(TopicType),
+    Service(TopicType),
     Stream(TopicType, TopicType),
 }
 
@@ -65,12 +66,20 @@ impl TopicSchema {
             _ => false,
         }
     }
+
+    pub fn is_service(&self) -> bool {
+        match *self {
+            TopicSchema::Service(_) => true,
+            _ => false,
+        }
+    }
 }
 
 impl fmt::Display for TopicSchema {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TopicSchema::Collection(ref d) => write!(f, "Collection(item={:?})", d.name),
+            TopicSchema::Service(ref d) => write!(f, "Service(item={:?})", d.name),
             TopicSchema::Stream(ref d, ref t) => {
                 write!(f, "Stream(timestamp={:?}, data={:?})", t.name, d.name)
             }

--- a/tests/simple-pubsub/Cargo.toml
+++ b/tests/simple-pubsub/Cargo.toml
@@ -5,6 +5,13 @@ version = "0.1.0"
 
 [dependencies]
 timely = "0.3.0"
+serde = "1"
+serde_derive = "1"
+typename = "0.1"
+futures = "0.1"
 
 [dependencies.strymon_job]
 path = "../../src/strymon_job"
+
+[dependencies.strymon_communication]
+path = "../../src/strymon_communication"

--- a/tests/simple-pubsub/src/bin/service.rs
+++ b/tests/simple-pubsub/src/bin/service.rs
@@ -1,0 +1,88 @@
+// Copyright 2018 ETH Zurich. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate futures;
+extern crate timely;
+
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate typename;
+
+extern crate strymon_job;
+extern crate strymon_communication;
+
+use std::thread;
+
+use futures::Stream;
+use timely::dataflow::operators::{Input, Inspect};
+
+use strymon_job::operators::service::Service;
+use strymon_communication::rpc::{Name, Request};
+
+// === Service Interface ===
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, TypeName)]
+pub enum PingService {
+    Ping,
+}
+
+impl Name for PingService {
+    type Discriminant = u8;
+
+    fn discriminant(&self) -> Self::Discriminant {
+        0
+    }
+
+    fn from_discriminant(value: &Self::Discriminant) -> Option<Self> {
+        match *value {
+            0 => Some(PingService::Ping),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct Ping(String);
+
+impl Request<PingService> for Ping {
+    const NAME: PingService = PingService::Ping;
+    type Success = String;
+    type Error = ();
+}
+// === End of Interface ===
+
+fn handle_requests(server: Service<PingService>) {
+    thread::spawn(move || {
+        let blocking = server.wait();
+        for req in blocking {
+            let req = req.unwrap();
+            assert_eq!(req.name(), &PingService::Ping);
+            let (Ping(s), resp) = req.decode::<Ping>().unwrap();
+            resp.respond(Ok(s));
+        }
+    });
+}
+
+fn main() {
+    strymon_job::execute(|root, coord| {
+        let mut input = root.dataflow::<u64, _, _>(|scope| {
+            let (input, stream) = scope.new_input();
+            stream.inspect(|x| println!("got response {:?}", x));
+            input
+        });
+
+        let server = coord.announce_service("test_ping_service").unwrap();
+        let client = coord.bind_service("test_ping_service", false).unwrap();
+
+        handle_requests(server);
+
+        let resp = client.request(&Ping(String::from("Hello, world!")));
+        input.send(resp.wait_unwrap());
+    }).unwrap();
+}

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -90,6 +90,13 @@ test_example() {
      terminate "${topo_id}"
 }
 
+## Test for simple services
+test_service() {
+     id=$(submit --bin service "${BASEDIR}/simple-pubsub")
+     # wait for subscriber to receive some tuples
+     wait_job_output "${id}" 'got response Ok\("Hello, world\!"\)'
+}
+
 #
 # main
 #
@@ -101,7 +108,7 @@ echo "Test artifacts in: ${OUTDIR}"
 start_strymon
 trap error_handler EXIT
 
-TESTS=(test_example test_pubsub test_partitioned_pubsub)
+TESTS=(test_example test_pubsub test_partitioned_pubsub test_service)
 
 for test in ${TESTS[@]}; do
     echo "===== Running '$test' ====="


### PR DESCRIPTION
This adds another kind of topic in the model for exposing `strymon_communication` [request-response services](https://strymon-system.github.io/strymon-core/strymon_communication/rpc/index.html). This is intended as a replacement for the collection-publisher hack, which I intended to remove for a long time now.

The basic functionally allows Strymon jobs to connect and communicate over a simple request-response mechanism where one job acts as a request server and the other as a client. Both the interface and the implementation are intentionally kept very minimalistic, as this is not indented as a full-fledged solution for building communicating services. The indented purpose of this is retrieving application data in a newly spawned job (e.g. fetching initialization or configuration data from an already existing job).

Ideally, this is eventually replaced by a proper state management solution.