### PR TITLE
strymon_rpc: Add basic documentation

### DIFF
--- a/src/strymon_rpc/src/coordinator/catalog.rs
+++ b/src/strymon_rpc/src/coordinator/catalog.rs
@@ -6,18 +6,27 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! This module contains the queries which can be submitted to the catalog service to inspect
+//! the current state of the system.
+
 use num_traits::FromPrimitive;
 
 use strymon_model::*;
 use strymon_communication::rpc::{Name, Request};
 
+/// The list of available methods to query the catalog.
 #[derive(Primitive, Debug, PartialEq, Eq, Clone, Copy, TypeName)]
 #[repr(u8)]
 pub enum CatalogRPC {
+    /// Return a list of all created topics.
     AllTopics = 1,
+    /// Return a list of all available executors.
     AllExecutors = 2,
+    /// Return a list of all running jobs.
     AllQueries = 3,
+    /// Return a list of all publications.
     AllPublications = 4,
+    /// Return a list of all subscriptions.
     AllSubscriptions = 5,
 }
 
@@ -33,15 +42,17 @@ impl Name for CatalogRPC {
 }
 
 macro_rules! impl_request {
-    ( $req:ident, $resp:ty ) => {
+    ( $req:ident, $resp:ty, $doc:expr) => {
         // TODO(swicki): All these requests could be represented as a unit struct,
         // however due to https://github.com/3Hren/msgpack-rust/issues/159 we currently
         // need to have some some dummy struct members.
 
         #[derive(Debug, Clone, Serialize, Deserialize)]
+        #[doc=$doc]
         pub struct $req(());
 
         impl $req {
+            #[doc="Creates a new instance of this request type."]
             pub fn new() -> Self {
                 $req (())
             }
@@ -56,8 +67,8 @@ macro_rules! impl_request {
     }
 }
 
-impl_request!(AllTopics, Vec<Topic>);
-impl_request!(AllExecutors, Vec<Executor>);
-impl_request!(AllQueries, Vec<Query>);
-impl_request!(AllPublications, Vec<Publication>);
-impl_request!(AllSubscriptions, Vec<Subscription>);
+impl_request!(AllTopics, Vec<Topic>, "The request type use to query a list of all topics.");
+impl_request!(AllExecutors, Vec<Executor>, "The request type use to query a list of all executors.");
+impl_request!(AllQueries, Vec<Query>, "The request type use to query a list of all jobs.");
+impl_request!(AllPublications, Vec<Publication>, "The request type use to query a list of all publications.");
+impl_request!(AllSubscriptions, Vec<Subscription>, "The request type use to query a list of all subscriptions.");

--- a/src/strymon_rpc/src/executor/mod.rs
+++ b/src/strymon_rpc/src/executor/mod.rs
@@ -6,15 +6,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! The interface exposed by executors. This interface is currently only intended to be used by the
+//! coordinator to send requests to a registered executor.
+
 use num_traits::FromPrimitive;
 
 use strymon_model::*;
 use strymon_communication::rpc::{Name, Request};
 
+/// The list of available requests an executor can serve.
 #[derive(Primitive, Debug, PartialEq, Eq, Clone, Copy)]
 #[repr(u8)]
 pub enum ExecutorRPC {
+    /// Request to spawn a new job worker group.
     SpawnQuery = 1,
+    /// Request to terminate a running job.
     TerminateQuery = 2,
 }
 
@@ -30,18 +36,27 @@ impl Name for ExecutorRPC {
     }
 }
 
+/// A request to spawn a new worker group.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SpawnQuery {
+    /// The meta-data of the job worker group to spawn.
     pub query: Query,
+    /// The hostlist to be passed to `timely_communication`.
     pub hostlist: Vec<String>,
 }
 
+/// The error message returned by the executor for failed spawn requests.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SpawnError {
+    /// The request was invalid.
     InvalidRequest,
+    /// The executor was unable to locate the downloaded file.
     FileNotFound,
+    /// The working directory for the job could not be created.
     WorkdirCreationFailed,
+    /// The executable was unable to fetch the executable file.
     FetchFailed,
+    /// Launching the executable failed.
     ExecFailed,
 }
 
@@ -52,14 +67,19 @@ impl Request<ExecutorRPC> for SpawnQuery {
     const NAME: ExecutorRPC = ExecutorRPC::SpawnQuery;
 }
 
+/// A request to terminate a running job.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TerminateQuery {
+    /// The job to terminate.
     pub query: QueryId,
 }
 
+/// The error message returned by the executor if job termination fails.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TerminateError {
+    /// The specified job is not running on this executor.
     NotFound,
+    /// This implementation of the executor does not support job termination.
     OperationNotSupported,
 }
 

--- a/src/strymon_rpc/src/lib.rs
+++ b/src/strymon_rpc/src/lib.rs
@@ -5,6 +5,17 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#![deny(missing_docs)]
+
+//! This crate defines the remote-procedure call protocol used between the different components
+//! in Strymon Core.
+//!
+//! All types here are based on the framework outlined in
+//! [**`strymon_communication::rpc`**](../strymon_communication/rpc/index.html). Each submodule
+//! contains the type definitions for one interface. The [`coordinator`](coordinator/index.html)
+//! module contains all requests sent to the coordinator by various components, while the
+//! [`executor`](executor/index.html) contains the messages sent from the coordinator to a
+//! registered executor.
 
 #[macro_use]
 extern crate enum_primitive_derive;


### PR DESCRIPTION
This adds `!#[deny(missing_docs)]` to the `strymon_rpc` crate.

Signed-off-by: Sebastian Wicki <swicki@inf.ethz.ch>