### PR TITLE
 strymon_job: Do not remove frontier elements from subscriber filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmpv"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +555,7 @@ dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmpv 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -953,6 +963,7 @@ dependencies = [
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
 "checksum rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a3d45d7afc9b132b34a2479648863aa95c5c88e98b32285326a6ebadc80ec5c9"
 "checksum rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "011e1d58446e9fa3af7cdc1fb91295b10621d3ac4cb3a85cc86385ee9ca50cd3"
+"checksum rmpv 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29af0205707de955a396a1d3c657677c65f791ebabb63c0596c0b2fec0bf6325"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
 "checksum serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "db99f3919e20faa51bb2996057f5031d8685019b5a06139b1ce761da671b8526"

--- a/src/strymon_communication/Cargo.toml
+++ b/src/strymon_communication/Cargo.toml
@@ -3,13 +3,19 @@ authors = ["Sebastian Wicki <swicki@inf.ethz.ch>"]
 name = "strymon_communication"
 version = "0.1.2"
 
+[features]
+default = []
+# enables the `MessageBuf::debug()` printer
+tracing = ["rmpv"]
+
 [dependencies]
-bytes = "0.4"
 byteorder = "1.0"
-serde = "1.0"
-rmp-serde = "0.13"
+bytes = "0.4"
 futures = "0.1"
 log = "0.4"
+rmp-serde = "0.13"
+rmpv = { version = "0.4", optional = true }
+serde = "1.0"
 
 [dev-dependencies]
 serde_derive = "1.0"

--- a/src/strymon_communication/src/lib.rs
+++ b/src/strymon_communication/src/lib.rs
@@ -27,6 +27,8 @@ extern crate byteorder;
 
 extern crate serde;
 extern crate rmp_serde;
+#[cfg(feature = "tracing")]
+extern crate rmpv;
 
 extern crate futures;
 

--- a/src/strymon_communication/src/rpc.rs
+++ b/src/strymon_communication/src/rpc.rs
@@ -518,12 +518,15 @@ impl<N: Name> Stream for Server<N> {
 
 /// creates a new request dispatcher/multiplexer for each accepted tcp socket
 fn multiplex<N: Name>(stream: TcpStream) -> io::Result<(Outgoing, Incoming<N>)> {
+    let local = stream.local_addr()?;
+    let remote = stream.peer_addr()?;
+
     let instream = stream.try_clone()?;
     let outstream = stream;
 
     let (incoming_tx, incoming_rx) = mpsc::unbounded();
     let pending = Arc::new(Mutex::new(HashMap::new()));
-    let sender = transport::Sender::new(outstream);
+    let sender = transport::Sender::new(outstream, local, remote);
 
     let resolver = Resolver {
         pending: pending.clone(),

--- a/src/strymon_job/src/operators/service.rs
+++ b/src/strymon_job/src/operators/service.rs
@@ -55,7 +55,7 @@ impl<N: Name> Stream for Service<N> {
             Ok(Async::Ready(None)) if !self.server.is_done() => {
                 // we don't have any clients, but the server is still alive
                 Ok(Async::NotReady)
-            },
+            }
             other => other,
         }
     }
@@ -95,9 +95,10 @@ impl Coordinator {
     /// Given a service interface definition and a name, creates a new server
     /// for receiving incoming requests. A topic is created under the specified
     /// name which is used by clients to bind to the service.
-    pub fn announce_service<N: Name + TypeName>(&self, name: &str)
-        -> Result<Service<N>, PublicationError>
-    {
+    pub fn announce_service<N: Name + TypeName>(
+        &self,
+        name: &str,
+    ) -> Result<Service<N>, PublicationError> {
         // create a new service and obtain its address
         let server = self.network.server(None)?.fuse();
         let addr = {
@@ -110,7 +111,12 @@ impl Coordinator {
         let topic = self.publish_request(name.to_string(), schema, addr)?;
         let clients = StreamsUnordered::new();
         let coord = self.clone();
-        Ok(Service { server, clients, topic, coord })
+        Ok(Service {
+            server,
+            clients,
+            topic,
+            coord,
+        })
     }
 
     /// Creates a binding to a service topic for sending requests.
@@ -123,13 +129,15 @@ impl Coordinator {
     /// When `blocking` is true, this call blocks until a remote job registers
     /// a service with the matching name. If `blocking` is false, the call
     /// returns with an error if the topic does not exist.
-    pub fn bind_service<N: Name + TypeName>(&self, name: &str, blocking: bool)
-        -> Result<Client<N>, SubscriptionError>
-    {
+    pub fn bind_service<N: Name + TypeName>(
+        &self,
+        name: &str,
+        blocking: bool,
+    ) -> Result<Client<N>, SubscriptionError> {
         let topic = self.subscribe_request(name, blocking)?;
         let schema = TopicSchema::Service(TopicType::of::<N>());
         if topic.schema != schema {
-            return Err(SubscriptionError::TypeMismatch)
+            return Err(SubscriptionError::TypeMismatch);
         }
 
         let queue = {
@@ -139,6 +147,11 @@ impl Coordinator {
         };
         let coord = self.clone();
         let name = PhantomData;
-        Ok(Client { queue, topic, coord, name })
+        Ok(Client {
+            queue,
+            topic,
+            coord,
+            name,
+        })
     }
 }

--- a/src/strymon_job/src/publisher/progress.rs
+++ b/src/strymon_job/src/publisher/progress.rs
@@ -26,17 +26,21 @@ pub struct UpperFrontier<T: Timestamp> {
 impl<T: Timestamp> UpperFrontier<T> {
     /// Creates a new empty upper frontier.
     pub fn empty() -> Self {
-        UpperFrontier {
-            antichain: Antichain::new(),
-        }
+        UpperFrontier { antichain: Antichain::new() }
     }
 
     #[cfg(test)]
     /// Returns true if any item in the antichain is greater or equal than the argument.
     pub fn greater_equal(&self, other: &T) -> bool {
         // SAFETY: This assumes that Rev<T> and T use the same memory layout
-        debug_assert_eq!(::std::mem::size_of::<&Rev<T>>(), ::std::mem::size_of::<&T>());
-        debug_assert_eq!(::std::mem::align_of::<&Rev<T>>(), ::std::mem::align_of::<&T>());
+        debug_assert_eq!(
+            ::std::mem::size_of::<&Rev<T>>(),
+            ::std::mem::size_of::<&T>()
+        );
+        debug_assert_eq!(
+            ::std::mem::align_of::<&Rev<T>>(),
+            ::std::mem::align_of::<&T>()
+        );
 
         let rev: &Rev<T> = unsafe { ::std::mem::transmute(other) };
 
@@ -55,7 +59,10 @@ impl<T: Timestamp> UpperFrontier<T> {
     pub fn elements(&self) -> &[T] {
         // SAFETY: This assumes that Rev<T> and T use the same memory layout
         debug_assert_eq!(::std::mem::size_of::<Rev<T>>(), ::std::mem::size_of::<T>());
-        debug_assert_eq!(::std::mem::align_of::<Rev<T>>(), ::std::mem::align_of::<T>());
+        debug_assert_eq!(
+            ::std::mem::align_of::<Rev<T>>(),
+            ::std::mem::align_of::<T>()
+        );
 
         let ptr = self.antichain.elements().as_ptr() as *const T;
         let len = self.antichain.elements().len();
@@ -73,13 +80,17 @@ pub struct LowerFrontier<T: Timestamp> {
 }
 
 impl<T: Timestamp> LowerFrontier<T> {
-    /// Updates the frontier and compacts the argument to reflect only the externally visible changes.
+    /// Updates the frontier and compacts the argument to reflect only the externally
+    /// visible changes.
     pub fn update(&mut self, updates: &mut Vec<(T, i64)>) {
         for (t, delta) in updates.drain(..) {
             self.antichain.update_dirty(t, delta);
         }
 
-        self.antichain.update_iter_and(None, |t, i| updates.push((t.clone(), i)));
+        self.antichain.update_iter_and(
+            None,
+            |t, i| updates.push((t.clone(), i)),
+        );
     }
 
     /// Reveals the minimal elements in the frontier.
@@ -90,9 +101,7 @@ impl<T: Timestamp> LowerFrontier<T> {
 
 impl<T: Timestamp> Default for LowerFrontier<T> {
     fn default() -> Self {
-        LowerFrontier {
-            antichain: MutableAntichain::new_bottom(Default::default()),
-        }
+        LowerFrontier { antichain: MutableAntichain::new_bottom(Default::default()) }
     }
 }
 

--- a/src/strymon_job/src/subscriber.rs
+++ b/src/strymon_job/src/subscriber.rs
@@ -257,10 +257,10 @@ struct Filter<T> {
 }
 
 impl<T: Timestamp> Filter<T> {
-    /// Removes all elements from the filter which are less or equal than any element in `frontier`
+    /// Removes all elements from the filter which are strictly less than any element in `frontier`
     fn remove(&mut self, frontier: &[T]) {
         self.filter.retain(
-            |t| !frontier.iter().any(|f| t.less_equal(f)),
+            |t| !frontier.iter().any(|f| t.less_than(f)),
         )
     }
 

--- a/src/strymon_job/src/subscriber.rs
+++ b/src/strymon_job/src/subscriber.rs
@@ -23,7 +23,7 @@ use timely::progress::frontier::MutableAntichain;
 use strymon_communication::transport::{Sender, Receiver};
 
 use protocol::{Message, InitialSnapshot, RemoteTimestamp};
-use publisher::progress::{UpperFrontier};
+use publisher::progress::UpperFrontier;
 use util::StreamsUnordered;
 
 /// Data or frontier events emitted by a subscription.
@@ -48,16 +48,17 @@ pub struct SubscriberGroup<T: Timestamp, D> {
 }
 
 impl<T, D> SubscriberGroup<T, D>
-    where T: RemoteTimestamp, D: DeserializeOwned,
+where
+    T: RemoteTimestamp,
+    D: DeserializeOwned,
 {
     /// Creates a new driver for managing a subscriber group.
     ///
-    /// The `root` capability is used to maintain the input frontier, it is
-    /// typically the one returned by `unordered_input`.
     /// Returns a future which resolves once all connections have received
     /// their `InitialSnapshot`.
     pub fn new<I>(connections: I) -> ConnectingGroup<T, D>
-        where I: IntoIterator<Item=(Sender, Receiver)>,
+    where
+        I: IntoIterator<Item = (Sender, Receiver)>,
     {
         let connecting = connections.into_iter().map(Connecting::new);
         ConnectingGroup {
@@ -66,7 +67,7 @@ impl<T, D> SubscriberGroup<T, D>
                 ready: StreamsUnordered::new(),
                 frontier: MutableAntichain::new(),
                 upper: UpperFrontier::empty(),
-            })
+            }),
         }
     }
 
@@ -75,9 +76,10 @@ impl<T, D> SubscriberGroup<T, D>
     }
 
     /// Drives the subscriber logic based on a received message.
-    fn process_message(&mut self, msg: Message<T, D>)
-        -> io::Result<Option<SubscriptionEvent<T, D>>>
-    {
+    fn process_message(
+        &mut self,
+        msg: Message<T, D>,
+    ) -> io::Result<Option<SubscriptionEvent<T, D>>> {
         match msg {
             Message::LowerFrontierUpdate { update } => {
                 self.frontier.update_iter(update);
@@ -85,7 +87,7 @@ impl<T, D> SubscriberGroup<T, D>
                 self.filter.remove(frontier);
 
                 Ok(Some(SubscriptionEvent::FrontierUpdate))
-            },
+            }
             Message::DataMessage { time, data } => {
                 if !self.filter.contains(&time) {
                     Ok(Some(SubscriptionEvent::Data(time, data.decode()?)))
@@ -98,7 +100,9 @@ impl<T, D> SubscriberGroup<T, D>
 }
 
 impl<T, D> Stream for SubscriberGroup<T, D>
-    where T: RemoteTimestamp, D: DeserializeOwned,
+where
+    T: RemoteTimestamp,
+    D: DeserializeOwned,
 {
     type Item = SubscriptionEvent<T, D>;
     type Error = io::Error;
@@ -122,7 +126,9 @@ pub struct ConnectingGroup<T: Timestamp, D> {
 }
 
 impl<T, D> Future for ConnectingGroup<T, D>
-    where T: RemoteTimestamp, D: DeserializeOwned,
+where
+    T: RemoteTimestamp,
+    D: DeserializeOwned,
 {
     type Item = SubscriberGroup<T, D>;
     type Error = io::Error;
@@ -149,7 +155,9 @@ struct GroupBuilder<T: Timestamp, D> {
 }
 
 impl<T, D> GroupBuilder<T, D>
-    where T: RemoteTimestamp, D: DeserializeOwned
+where
+    T: RemoteTimestamp,
+    D: DeserializeOwned,
 {
     /// Marks a subscriber as connected (provided we have its initial state).
     ///
@@ -161,7 +169,9 @@ impl<T, D> GroupBuilder<T, D>
             self.upper.insert(t);
         }
 
-        self.frontier.update_iter(snapshot.lower.into_iter().map(|t| (t, 1)));
+        self.frontier.update_iter(
+            snapshot.lower.into_iter().map(|t| (t, 1)),
+        );
     }
 
     /// Builds the subscriber group, assuming all clients are connected.
@@ -192,7 +202,9 @@ impl<T, D> Connecting<T, D> {
 }
 
 impl<T, D> Future for Connecting<T, D>
-    where T: RemoteTimestamp, D: DeserializeOwned,
+where
+    T: RemoteTimestamp,
+    D: DeserializeOwned,
 {
     type Item = (InitialSnapshot<T>, Subscriber<T, D>);
     type Error = io::Error;
@@ -201,10 +213,13 @@ impl<T, D> Future for Connecting<T, D>
         if let Some(buf) = try_ready!(self.socket.as_mut().unwrap().1.poll()) {
             let snapshot = InitialSnapshot::decode(buf)?;
             let socket = self.socket.take().unwrap();
-            Ok(Async::Ready((snapshot, Subscriber {
-                socket: socket,
-                marker: self.marker,
-            })))
+            Ok(Async::Ready((
+                snapshot,
+                Subscriber {
+                    socket: socket,
+                    marker: self.marker,
+                },
+            )))
         } else {
             Err(io::Error::from(io::ErrorKind::UnexpectedEof))
         }
@@ -219,7 +234,9 @@ struct Subscriber<T, D> {
 }
 
 impl<T, D> Stream for Subscriber<T, D>
-    where T: RemoteTimestamp, D: DeserializeOwned,
+where
+    T: RemoteTimestamp,
+    D: DeserializeOwned,
 {
     type Item = Message<T, D>;
     type Error = io::Error;
@@ -242,9 +259,9 @@ struct Filter<T> {
 impl<T: Timestamp> Filter<T> {
     /// Removes all elements from the filter which are less or equal than any element in `frontier`
     fn remove(&mut self, frontier: &[T]) {
-        self.filter.retain(|t| {
-            !frontier.iter().any(|f| t.less_equal(f))
-        })
+        self.filter.retain(
+            |t| !frontier.iter().any(|f| t.less_equal(f)),
+        )
     }
 
     /// Returns `true` if `time` is less or equal than any element in the filter.

--- a/src/strymon_job/src/util.rs
+++ b/src/strymon_job/src/util.rs
@@ -10,9 +10,7 @@ pub struct StreamsUnordered<S> {
 impl<S: Stream> StreamsUnordered<S> {
     /// Creates an empty polling set.
     pub fn new() -> Self {
-        StreamsUnordered {
-            inner: FuturesUnordered::new(),
-        }
+        StreamsUnordered { inner: FuturesUnordered::new() }
     }
 
     /// Adds a stream to the polling set.
@@ -32,7 +30,7 @@ impl<S: Stream> Stream for StreamsUnordered<S> {
                     // stream returned a value, reregister and yield value
                     self.push(stream);
                     return Ok(Async::Ready(Some(val)));
-                },
+                }
                 Ok(Async::Ready(Some((None, stream)))) => {
                     // stream exhausted, drop it and try next one
                     drop(stream);
@@ -50,7 +48,7 @@ impl<S: Stream> Stream for StreamsUnordered<S> {
                     // stream returned an error, reregister and yield error
                     self.push(stream);
                     return Err(err);
-                },
+                }
             }
         }
     }


### PR DESCRIPTION
This fixes a bug where elements were removed from the filter too early. The old implementation removed elements which became part of the frontier. This is wrong, as elements in the frontier are still part of the `active` set and thus can still be observed. Only elements strictly smaller than the frontier can be removed safely from the filter, as only they are guaranteed to be never observed again.

This PR also adds a bunch of cleanup which occurred during debugging. This should fix the failing CI on the other two pending PRs. 