### PR TITLE
Rename "Query" to "Job"

### DIFF
--- a/src/strymon_cli/src/status.rs
+++ b/src/strymon_cli/src/status.rs
@@ -33,7 +33,7 @@ pub fn main(args: &ArgMatches) -> Result<(), Error> {
     let submitter = Submitter::new(&network, &*coord)?;
 
     let executors = submitter.executors()?;
-    let queries = submitter.queries()?;
+    let jobs = submitter.jobs()?;
     let publications = submitter.publications()?;
     let subscriptions = submitter.subscriptions()?;
     let topics = submitter
@@ -46,20 +46,20 @@ pub fn main(args: &ArgMatches) -> Result<(), Error> {
     for executor in executors {
         let id = executor.id.0;
         println!(" Executor {}: host={:?}", id, executor.host);
-        for query in queries.iter().filter(
+        for job in jobs.iter().filter(
             |q| q.executors.contains(&executor.id),
         )
         {
-            let id = query.id.0;
-            let name = query
+            let id = job.id.0;
+            let name = job
                 .name
                 .as_ref()
                 .map(|n| format!("{:?}", n))
                 .unwrap_or_else(|| String::from("<unnamed>"));
 
-            println!("  Job {}: name={}, workers={}", id, name, query.workers);
+            println!("  Job {}: name={}, workers={}", id, name, job.workers);
 
-            for publication in publications.iter().filter(|p| p.0 == query.id) {
+            for publication in publications.iter().filter(|p| p.0 == job.id) {
                 let topic = &topics[&publication.1];
                 println!(
                     "   Publication on Topic {}: name={:?}, schema={}",
@@ -69,7 +69,7 @@ pub fn main(args: &ArgMatches) -> Result<(), Error> {
                 );
             }
 
-            for subscription in subscriptions.iter().filter(|p| p.0 == query.id) {
+            for subscription in subscriptions.iter().filter(|p| p.0 == job.id) {
                 let topic = &topics[&subscription.1];
                 println!(
                     "   Subscription on Topic {}: name={:?}, schema={}",

--- a/src/strymon_cli/src/status.rs
+++ b/src/strymon_cli/src/status.rs
@@ -57,7 +57,7 @@ pub fn main(args: &ArgMatches) -> Result<(), Error> {
                 .map(|n| format!("{:?}", n))
                 .unwrap_or_else(|| String::from("<unnamed>"));
 
-            println!("  Query {}: name={}, workers={}", id, name, query.workers);
+            println!("  Job {}: name={}, workers={}", id, name, query.workers);
 
             for publication in publications.iter().filter(|p| p.0 == query.id) {
                 let topic = &topics[&publication.1];

--- a/src/strymon_cli/src/submit/mod.rs
+++ b/src/strymon_cli/src/submit/mod.rs
@@ -14,7 +14,7 @@ use clap::{App, AppSettings, Arg, ArgGroup, ArgMatches, SubCommand};
 use failure::{Error, ResultExt};
 
 use strymon_communication::Network;
-use strymon_model::{QueryProgram, QueryId, ExecutionFormat, Executor, ExecutorId};
+use strymon_model::{QueryProgram, JobId, ExecutionFormat, Executor, ExecutorId};
 use strymon_rpc::coordinator::Placement;
 
 pub use self::submitter::Submitter;
@@ -72,7 +72,7 @@ fn parse_placement(args: &ArgMatches, executors: Vec<Executor>) -> Result<Placem
     }
 }
 
-fn submit_binary(binary: String, args: &ArgMatches) -> Result<QueryId, Error> {
+fn submit_binary(binary: String, args: &ArgMatches) -> Result<JobId, Error> {
     eprintln!("Submitting binary {:?}", binary);
 
     let coord = args.value_of("coordinator").unwrap_or("localhost:9189");

--- a/src/strymon_cli/src/submit/mod.rs
+++ b/src/strymon_cli/src/submit/mod.rs
@@ -14,7 +14,7 @@ use clap::{App, AppSettings, Arg, ArgGroup, ArgMatches, SubCommand};
 use failure::{Error, ResultExt};
 
 use strymon_communication::Network;
-use strymon_model::{QueryProgram, JobId, ExecutionFormat, Executor, ExecutorId};
+use strymon_model::{JobProgram, JobId, ExecutionFormat, Executor, ExecutorId};
 use strymon_rpc::coordinator::Placement;
 
 pub use self::submitter::Submitter;
@@ -113,7 +113,7 @@ fn submit_binary(binary: String, args: &ArgMatches) -> Result<JobId, Error> {
         Vec::new()
     };
 
-    let query = QueryProgram {
+    let query = JobProgram {
         binary_name: binary_name,
         source: url,
         format: ExecutionFormat::NativeExecutable,

--- a/src/strymon_cli/src/submit/mod.rs
+++ b/src/strymon_cli/src/submit/mod.rs
@@ -113,7 +113,7 @@ fn submit_binary(binary: String, args: &ArgMatches) -> Result<JobId, Error> {
         Vec::new()
     };
 
-    let query = JobProgram {
+    let job = JobProgram {
         binary_name: binary_name,
         source: url,
         format: ExecutionFormat::NativeExecutable,
@@ -121,7 +121,7 @@ fn submit_binary(binary: String, args: &ArgMatches) -> Result<JobId, Error> {
     };
 
     let res = submitter
-        .submit(query, desc, placement)
+        .submit(job, desc, placement)
         .wait_unwrap()
         .map_err(|e| format_err!("Failed to submit job: {:?}", e).into());
 

--- a/src/strymon_cli/src/submit/submitter.rs
+++ b/src/strymon_cli/src/submit/submitter.rs
@@ -38,7 +38,7 @@ impl Submitter {
 
     pub fn submit<N>(
         &self,
-        query: JobProgram,
+        job: JobProgram,
         name: N,
         placement: Placement,
     ) -> Response<CoordinatorRPC, Submission>
@@ -46,7 +46,7 @@ impl Submitter {
         N: Into<Option<String>>,
     {
         let submission = Submission {
-            query: query,
+            job: job,
             name: name.into(),
             placement: placement,
         };
@@ -55,7 +55,7 @@ impl Submitter {
     }
 
     pub fn terminate(&self, id: JobId) -> Response<CoordinatorRPC, Termination> {
-        let termination = Termination { query: id };
+        let termination = Termination { job: id };
 
         self.coord.request(&termination)
     }
@@ -76,7 +76,7 @@ impl Submitter {
         )
     }
 
-    pub fn queries(&self) -> Result<Vec<Job>> {
+    pub fn jobs(&self) -> Result<Vec<Job>> {
         self.catalog.request(&AllJobs::new()).wait().map_err(
             |err| {
                 err.unwrap_err()

--- a/src/strymon_cli/src/submit/submitter.rs
+++ b/src/strymon_cli/src/submit/submitter.rs
@@ -77,7 +77,7 @@ impl Submitter {
     }
 
     pub fn queries(&self) -> Result<Vec<Job>> {
-        self.catalog.request(&AllQueries::new()).wait().map_err(
+        self.catalog.request(&AllJobs::new()).wait().map_err(
             |err| {
                 err.unwrap_err()
             },

--- a/src/strymon_cli/src/submit/submitter.rs
+++ b/src/strymon_cli/src/submit/submitter.rs
@@ -38,7 +38,7 @@ impl Submitter {
 
     pub fn submit<N>(
         &self,
-        query: QueryProgram,
+        query: JobProgram,
         name: N,
         placement: Placement,
     ) -> Response<CoordinatorRPC, Submission>

--- a/src/strymon_cli/src/submit/submitter.rs
+++ b/src/strymon_cli/src/submit/submitter.rs
@@ -54,7 +54,7 @@ impl Submitter {
         self.coord.request(&submission)
     }
 
-    pub fn terminate(&self, id: QueryId) -> Response<CoordinatorRPC, Termination> {
+    pub fn terminate(&self, id: JobId) -> Response<CoordinatorRPC, Termination> {
         let termination = Termination { query: id };
 
         self.coord.request(&termination)

--- a/src/strymon_cli/src/submit/submitter.rs
+++ b/src/strymon_cli/src/submit/submitter.rs
@@ -76,7 +76,7 @@ impl Submitter {
         )
     }
 
-    pub fn queries(&self) -> Result<Vec<Query>> {
+    pub fn queries(&self) -> Result<Vec<Job>> {
         self.catalog.request(&AllQueries::new()).wait().map_err(
             |err| {
                 err.unwrap_err()

--- a/src/strymon_cli/src/terminate.rs
+++ b/src/strymon_cli/src/terminate.rs
@@ -9,7 +9,7 @@
 use clap::{App, Arg, ArgMatches, SubCommand};
 use failure::{Error, ResultExt};
 
-use strymon_model::QueryId;
+use strymon_model::JobId;
 use strymon_communication::Network;
 use super::submit::Submitter;
 
@@ -40,7 +40,7 @@ pub fn main(args: &ArgMatches) -> Result<(), Error> {
     let id = value_t!(args.value_of("job"), u64).context(
         "Unable to parse job id",
     )?;
-    submitter.terminate(QueryId(id)).wait_unwrap().map_err(
+    submitter.terminate(JobId(id)).wait_unwrap().map_err(
         |e| {
             format_err!("Failed to terminate job: {:?}", e)
         },

--- a/src/strymon_coordinator/src/catalog.rs
+++ b/src/strymon_coordinator/src/catalog.rs
@@ -164,8 +164,8 @@ impl Catalog {
                 let (_, resp) = req.decode::<AllExecutors>()?;
                 resp.respond(Ok(self.executors.values().cloned().collect()));
             },
-            CatalogRPC::AllQueries => {
-                let (_, resp) = req.decode::<AllQueries>()?;
+            CatalogRPC::AllJobs => {
+                let (_, resp) = req.decode::<AllJobs>()?;
                 resp.respond(Ok(self.queries.values().cloned().collect()));
             },
             CatalogRPC::AllPublications => {

--- a/src/strymon_coordinator/src/catalog.rs
+++ b/src/strymon_coordinator/src/catalog.rs
@@ -30,7 +30,7 @@ pub struct Catalog {
 
     topics: HashMap<TopicId, Topic>,
     executors: HashMap<ExecutorId, Executor>,
-    queries: HashMap<QueryId, Query>,
+    queries: HashMap<JobId, Query>,
 
     publications: HashSet<Publication>,
     subscriptions: HashSet<Subscription>,
@@ -79,13 +79,13 @@ impl Catalog {
         self.queries.insert(query.id, query);
     }
 
-    pub fn remove_query(&mut self, id: QueryId) {
+    pub fn remove_query(&mut self, id: JobId) {
         debug!("remove_query: {:?}", id);
         self.queries.remove(&id);
     }
 
     pub fn publish(&mut self,
-                   query: QueryId,
+                   query: JobId,
                    name: String,
                    addr: (String, u16),
                    schema: TopicSchema)
@@ -115,7 +115,7 @@ impl Catalog {
     }
 
     pub fn unpublish(&mut self,
-                     query_id: QueryId,
+                     query_id: JobId,
                      topic: TopicId)
                      -> Result<(), UnpublishError> {
         let publication = Publication(query_id, topic);
@@ -138,14 +138,14 @@ impl Catalog {
         }
     }
 
-    pub fn subscribe(&mut self, query_id: QueryId, topic: TopicId) {
+    pub fn subscribe(&mut self, query_id: JobId, topic: TopicId) {
         let subscription = Subscription(query_id, topic);
         debug!("subscribe: {:?}", subscription);
         self.subscriptions.insert(subscription);
     }
 
     pub fn unsubscribe(&mut self,
-                       query_id: QueryId,
+                       query_id: JobId,
                        topic: TopicId)
                        -> Result<(), UnsubscribeError> {
         let subscription = Subscription(query_id, topic);

--- a/src/strymon_coordinator/src/catalog.rs
+++ b/src/strymon_coordinator/src/catalog.rs
@@ -30,7 +30,7 @@ pub struct Catalog {
 
     topics: HashMap<TopicId, Topic>,
     executors: HashMap<ExecutorId, Executor>,
-    queries: HashMap<JobId, Job>,
+    jobs: HashMap<JobId, Job>,
 
     publications: HashSet<Publication>,
     subscriptions: HashSet<Subscription>,
@@ -74,28 +74,28 @@ impl Catalog {
         Executors { inner: self.executors.values() }
     }
 
-    pub fn add_query(&mut self, query: Job) {
-        debug!("add_query: {:?}", query);
-        self.queries.insert(query.id, query);
+    pub fn add_job(&mut self, job: Job) {
+        debug!("add_job: {:?}", job);
+        self.jobs.insert(job.id, job);
     }
 
-    pub fn remove_query(&mut self, id: JobId) {
-        debug!("remove_query: {:?}", id);
-        self.queries.remove(&id);
+    pub fn remove_job(&mut self, id: JobId) {
+        debug!("remove_job: {:?}", id);
+        self.jobs.remove(&id);
     }
 
     pub fn publish(&mut self,
-                   query: JobId,
+                   job: JobId,
                    name: String,
                    addr: (String, u16),
                    schema: TopicSchema)
                    -> Result<Topic, PublishError> {
-        // TODO(swicki): Check if query actually exists
+        // TODO(swicki): Check if job actually exists
         match self.directory.entry(name.clone()) {
             Entry::Occupied(_) => Err(PublishError::TopicAlreadyExists),
             Entry::Vacant(entry) => {
                 let id = self.generator.generate();
-                let publication = Publication(query, id);
+                let publication = Publication(job, id);
                 let topic = Topic {
                     id: id,
                     name: name,
@@ -115,10 +115,10 @@ impl Catalog {
     }
 
     pub fn unpublish(&mut self,
-                     query_id: JobId,
+                     job_id: JobId,
                      topic: TopicId)
                      -> Result<(), UnpublishError> {
-        let publication = Publication(query_id, topic);
+        let publication = Publication(job_id, topic);
         debug!("unpublish: {:?}", publication);
 
         if let Some(name) = self.topics.get(&topic).map(|t| &*t.name) {
@@ -138,17 +138,17 @@ impl Catalog {
         }
     }
 
-    pub fn subscribe(&mut self, query_id: JobId, topic: TopicId) {
-        let subscription = Subscription(query_id, topic);
+    pub fn subscribe(&mut self, job_id: JobId, topic: TopicId) {
+        let subscription = Subscription(job_id, topic);
         debug!("subscribe: {:?}", subscription);
         self.subscriptions.insert(subscription);
     }
 
     pub fn unsubscribe(&mut self,
-                       query_id: JobId,
+                       job_id: JobId,
                        topic: TopicId)
                        -> Result<(), UnsubscribeError> {
-        let subscription = Subscription(query_id, topic);
+        let subscription = Subscription(job_id, topic);
         debug!("unsubscribe: {:?}", subscription);
         self.subscriptions.remove(&subscription);
         Ok(())
@@ -166,7 +166,7 @@ impl Catalog {
             },
             CatalogRPC::AllJobs => {
                 let (_, resp) = req.decode::<AllJobs>()?;
-                resp.respond(Ok(self.queries.values().cloned().collect()));
+                resp.respond(Ok(self.jobs.values().cloned().collect()));
             },
             CatalogRPC::AllPublications => {
                 let (_, resp) = req.decode::<AllPublications>()?;

--- a/src/strymon_coordinator/src/catalog.rs
+++ b/src/strymon_coordinator/src/catalog.rs
@@ -30,7 +30,7 @@ pub struct Catalog {
 
     topics: HashMap<TopicId, Topic>,
     executors: HashMap<ExecutorId, Executor>,
-    queries: HashMap<JobId, Query>,
+    queries: HashMap<JobId, Job>,
 
     publications: HashSet<Publication>,
     subscriptions: HashSet<Subscription>,
@@ -74,7 +74,7 @@ impl Catalog {
         Executors { inner: self.executors.values() }
     }
 
-    pub fn add_query(&mut self, query: Query) {
+    pub fn add_query(&mut self, query: Job) {
         debug!("add_query: {:?}", query);
         self.queries.insert(query.id, query);
     }

--- a/src/strymon_coordinator/src/dispatch.rs
+++ b/src/strymon_coordinator/src/dispatch.rs
@@ -52,10 +52,10 @@ impl Dispatch {
                 self.handle.spawn(termination);
             }
             AddWorkerGroup::NAME => {
-                let (AddWorkerGroup { query, group }, resp) =
+                let (AddWorkerGroup { job, group }, resp) =
                     req.decode::<AddWorkerGroup>()?;
                 let response = self.coord
-                    .add_worker_group(query, group)
+                    .add_worker_group(job, group)
                     .then(|res| Ok(resp.respond(res)));
                 self.handle.spawn(response);
             }

--- a/src/strymon_coordinator/src/handler.rs
+++ b/src/strymon_coordinator/src/handler.rs
@@ -72,7 +72,7 @@ impl ExecutorState {
 
 enum QueryState {
     Spawning {
-        query: Query,
+        query: Job,
         submitter: Sender<Result<JobId, SubmissionError>>,
         waiting: Vec<Sender<Result<QueryToken, WorkerGroupError>>>,
     },
@@ -198,7 +198,7 @@ impl Coordinator {
             .unwrap_or(0);
 
         let executor_ids: Vec<_> = executors.iter().map(|e| e.id).collect();
-        let query = Query {
+        let query = Job {
             id: queryid,
             name: req.name,
             program: req.query,

--- a/src/strymon_coordinator/src/handler.rs
+++ b/src/strymon_coordinator/src/handler.rs
@@ -60,13 +60,13 @@ impl ExecutorState {
         self.ports.push_back(port);
     }
 
-    fn spawn(&self, req: &SpawnQuery) -> Response<ExecutorRPC, SpawnQuery> {
+    fn spawn(&self, req: &SpawnJob) -> Response<ExecutorRPC, SpawnJob> {
         debug!("issue spawn request {:?}", req);
         self.tx.request(req)
     }
 
-    fn terminate(&self, job_id: JobId) -> Response<ExecutorRPC, TerminateQuery> {
-        self.tx.request(&TerminateQuery { query: job_id })
+    fn terminate(&self, job_id: JobId) -> Response<ExecutorRPC, TerminateJob> {
+        self.tx.request(&TerminateJob { query: job_id })
     }
 }
 
@@ -206,7 +206,7 @@ impl Coordinator {
             executors: executor_ids.clone(),
             start_time: start_time,
         };
-        let spawnquery = SpawnQuery {
+        let spawnquery = SpawnJob {
             query: query.clone(),
             hostlist: hostlist,
         };

--- a/src/strymon_executor/src/lib.rs
+++ b/src/strymon_executor/src/lib.rs
@@ -84,7 +84,7 @@ impl ExecutorService {
         }
     }
 
-    fn spawn(&mut self, query: Query, hostlist: Vec<String>) -> Result<(), SpawnError> {
+    fn spawn(&mut self, query: Job, hostlist: Vec<String>) -> Result<(), SpawnError> {
         let process = query.executors
             .iter()
             .position(|&id| self.id == id)

--- a/src/strymon_executor/src/lib.rs
+++ b/src/strymon_executor/src/lib.rs
@@ -125,14 +125,14 @@ impl ExecutorService {
 
     pub fn dispatch(&mut self, req: RequestBuf<ExecutorRPC>) -> Result<(), Error> {
         match *req.name() {
-            SpawnQuery::NAME => {
-                let (SpawnQuery { query, hostlist }, resp) = req.decode::<SpawnQuery>()?;
+            SpawnJob::NAME => {
+                let (SpawnJob { query, hostlist }, resp) = req.decode::<SpawnJob>()?;
                 debug!("spawn request for {:?}", query);
                 resp.respond(self.spawn(query, hostlist));
                 Ok(())
             }
-            TerminateQuery::NAME => {
-                let (TerminateQuery { query }, resp) = req.decode::<TerminateQuery>()?;
+            TerminateJob::NAME => {
+                let (TerminateJob { query }, resp) = req.decode::<TerminateJob>()?;
                 debug!("termination request for {:?}", query);
                 resp.respond(self.process.terminate(query));
                 Ok(())

--- a/src/strymon_job/src/lib.rs
+++ b/src/strymon_job/src/lib.rs
@@ -100,7 +100,7 @@ impl Coordinator {
         let (tx, _) = network.client::<CoordinatorRPC, _>(&*coord)?;
 
         let announce = tx.request(&AddWorkerGroup {
-            query: id,
+            job: id,
             group: process,
         });
 

--- a/src/strymon_job/src/lib.rs
+++ b/src/strymon_job/src/lib.rs
@@ -73,7 +73,7 @@ use strymon_communication::Network;
 use strymon_communication::rpc::Outgoing;
 
 use strymon_rpc::coordinator::{QueryToken, AddWorkerGroup, CoordinatorRPC};
-use strymon_model::QueryId;
+use strymon_model::JobId;
 use strymon_model::config::job::Process;
 
 /// Handle to communicate with the Strymon coordinator.
@@ -91,7 +91,7 @@ pub struct Coordinator {
 impl Coordinator {
     /// Registers the local job at the coordinator at address `coord`.
     fn initialize(
-        id: QueryId,
+        id: JobId,
         process: usize,
         coord: String,
         hostname: String,

--- a/src/strymon_job/src/lib.rs
+++ b/src/strymon_job/src/lib.rs
@@ -72,7 +72,7 @@ use timely_communication::initialize::{Configuration, WorkerGuards};
 use strymon_communication::Network;
 use strymon_communication::rpc::Outgoing;
 
-use strymon_rpc::coordinator::{QueryToken, AddWorkerGroup, CoordinatorRPC};
+use strymon_rpc::coordinator::{JobToken, AddWorkerGroup, CoordinatorRPC};
 use strymon_model::JobId;
 use strymon_model::config::job::Process;
 
@@ -83,7 +83,7 @@ use strymon_model::config::job::Process;
 /// users must register the current process with `strymon_job::execute`.
 #[derive(Clone)]
 pub struct Coordinator {
-    token: QueryToken,
+    token: JobToken,
     network: Network,
     tx: Outgoing,
 }

--- a/src/strymon_model/src/config.rs
+++ b/src/strymon_model/src/config.rs
@@ -14,7 +14,7 @@ pub mod job {
     use std::env;
     use std::num;
 
-    use QueryId;
+    use JobId;
 
     /// The configuration of a job processes.
     ///
@@ -22,7 +22,7 @@ pub mod job {
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub struct Process {
         /// Job this process belongs to
-        pub job_id: QueryId,
+        pub job_id: JobId,
         /// Index of this process (worker group)
         pub index: usize,
         /// Addresses of all worker groups of this same job
@@ -46,7 +46,7 @@ pub mod job {
         /// Decodes the process configuration from the environment, i.e. using `std::env::var`.
         pub fn from_env() -> Result<Self, EnvError> {
             Ok(Process {
-                job_id: QueryId::from(env::var(JOB_ID)?.parse::<u64>()?),
+                job_id: JobId::from(env::var(JOB_ID)?.parse::<u64>()?),
                 index: env::var(PROCESS_INDEX)?.parse::<usize>()?,
                 addrs: env::var(PROCESS_ADDRS)?
                     .split('|')
@@ -121,7 +121,7 @@ pub mod job {
     #[cfg(test)]
     mod tests {
         use std::env;
-        use QueryId;
+        use JobId;
         use config::job::Process;
 
         #[test]
@@ -142,7 +142,7 @@ pub mod job {
             }
 
             assert_env_invariant(Process {
-                job_id: QueryId(1),
+                job_id: JobId(1),
                 index: 0,
                 addrs: vec![],
                 threads: 1,
@@ -150,7 +150,7 @@ pub mod job {
                 hostname: "bar".into(),
             });
             assert_env_invariant(Process {
-                job_id: QueryId(2),
+                job_id: JobId(2),
                 index: 0,
                 addrs: vec!["foo".into()],
                 threads: 4,
@@ -158,7 +158,7 @@ pub mod job {
                 hostname: "bar".into(),
             });
             assert_env_invariant(Process {
-                job_id: QueryId(3),
+                job_id: JobId(3),
                 index: 1,
                 addrs: vec!["host:1".into(), "host:2".into()],
                 threads: 1,

--- a/src/strymon_model/src/lib.rs
+++ b/src/strymon_model/src/lib.rs
@@ -153,7 +153,7 @@ pub struct Job {
     /// A human-readable description of the job.
     pub name: Option<String>,
     /// Information about the job executable.
-    pub program: QueryProgram,
+    pub program: JobProgram,
     /// The *total* amount of workers.
     pub workers: usize,
     /// A list of executors currently executing this job.
@@ -164,7 +164,7 @@ pub struct Job {
 
 /// The meta-data about the executable code of a job.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Abomonation, TypeName)]
-pub struct QueryProgram {
+pub struct JobProgram {
     /// The name of the binary submitted to Strymon.
     pub binary_name: String,
     /// The kind of the submitted executable.

--- a/src/strymon_model/src/lib.rs
+++ b/src/strymon_model/src/lib.rs
@@ -137,11 +137,11 @@ pub struct Topic {
 /// A unique numerical identifier for a job.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
          Abomonation, TypeName)]
-pub struct QueryId(pub u64);
+pub struct JobId(pub u64);
 
-impl From<u64> for QueryId {
-    fn from(id: u64) -> QueryId {
-        QueryId(id)
+impl From<u64> for JobId {
+    fn from(id: u64) -> JobId {
+        JobId(id)
     }
 }
 
@@ -149,7 +149,7 @@ impl From<u64> for QueryId {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Abomonation, TypeName)]
 pub struct Query {
     /// A unique identifier for this job.
-    pub id: QueryId,
+    pub id: JobId,
     /// A human-readable description of the job.
     pub name: Option<String>,
     /// Information about the job executable.
@@ -213,11 +213,11 @@ pub struct Executor {
 /// There can only be a single publication per topic. A job might publish multiple topics.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
          Abomonation, TypeName)]
-pub struct Publication(pub QueryId, pub TopicId);
+pub struct Publication(pub JobId, pub TopicId);
 
 /// Associates the subscription to a *topic* by a subscribing *job*.
 ///
 /// There can be many subscriptions on a topic. A job might subscribe to multiple topics.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
          Abomonation, TypeName)]
-pub struct Subscription(pub QueryId, pub TopicId);
+pub struct Subscription(pub JobId, pub TopicId);

--- a/src/strymon_model/src/lib.rs
+++ b/src/strymon_model/src/lib.rs
@@ -147,7 +147,7 @@ impl From<u64> for JobId {
 
 /// The meta-data of a submitted and running job.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Abomonation, TypeName)]
-pub struct Query {
+pub struct Job {
     /// A unique identifier for this job.
     pub id: JobId,
     /// A human-readable description of the job.

--- a/src/strymon_rpc/src/coordinator/catalog.rs
+++ b/src/strymon_rpc/src/coordinator/catalog.rs
@@ -69,6 +69,6 @@ macro_rules! impl_request {
 
 impl_request!(AllTopics, Vec<Topic>, "The request type use to query a list of all topics.");
 impl_request!(AllExecutors, Vec<Executor>, "The request type use to query a list of all executors.");
-impl_request!(AllQueries, Vec<Query>, "The request type use to query a list of all jobs.");
+impl_request!(AllQueries, Vec<Job>, "The request type use to query a list of all jobs.");
 impl_request!(AllPublications, Vec<Publication>, "The request type use to query a list of all publications.");
 impl_request!(AllSubscriptions, Vec<Subscription>, "The request type use to query a list of all subscriptions.");

--- a/src/strymon_rpc/src/coordinator/catalog.rs
+++ b/src/strymon_rpc/src/coordinator/catalog.rs
@@ -23,7 +23,7 @@ pub enum CatalogRPC {
     /// Return a list of all available executors.
     AllExecutors = 2,
     /// Return a list of all running jobs.
-    AllQueries = 3,
+    AllJobs = 3,
     /// Return a list of all publications.
     AllPublications = 4,
     /// Return a list of all subscriptions.
@@ -69,6 +69,6 @@ macro_rules! impl_request {
 
 impl_request!(AllTopics, Vec<Topic>, "The request type use to query a list of all topics.");
 impl_request!(AllExecutors, Vec<Executor>, "The request type use to query a list of all executors.");
-impl_request!(AllQueries, Vec<Job>, "The request type use to query a list of all jobs.");
+impl_request!(AllJobs, Vec<Job>, "The request type use to query a list of all jobs.");
 impl_request!(AllPublications, Vec<Publication>, "The request type use to query a list of all publications.");
 impl_request!(AllSubscriptions, Vec<Subscription>, "The request type use to query a list of all subscriptions.");

--- a/src/strymon_rpc/src/coordinator/mod.rs
+++ b/src/strymon_rpc/src/coordinator/mod.rs
@@ -138,7 +138,7 @@ impl Request<CoordinatorRPC> for AddExecutor {
 
 /// An opaque token used by job worker groups to authenticate themselves at the coordinator.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct QueryToken {
+pub struct JobToken {
     /// The job identifier of the token owner.
     pub id: JobId,
     /// A opaque random number only known to the job process and the coordinator.
@@ -166,7 +166,7 @@ pub enum WorkerGroupError {
 }
 
 impl Request<CoordinatorRPC> for AddWorkerGroup {
-    type Success = QueryToken;
+    type Success = JobToken;
     type Error = WorkerGroupError;
 
     const NAME: CoordinatorRPC = CoordinatorRPC::AddWorkerGroup;
@@ -181,7 +181,7 @@ pub struct Subscribe {
     /// Otherwise, an error message is returned indicating that the requested topic does not exist.
     pub blocking: bool,
     /// A token authenticating the the submitter as a successfully spawned job.
-    pub token: QueryToken,
+    pub token: JobToken,
 }
 
 /// The error message sent back to unsuccessful subscription requests.
@@ -206,7 +206,7 @@ pub struct Unsubscribe {
     /// The identifier of the subscribed topic.
     pub topic: TopicId,
     /// A token authenticating the the submitter as a successfully spawned job.
-    pub token: QueryToken,
+    pub token: JobToken,
 }
 
 /// The error message sent back for failed unsubscription request.
@@ -235,7 +235,7 @@ pub struct Publish {
     /// The kind of topic being published.
     pub schema: TopicSchema,
     /// A token authenticating the the submitter as a successfully spawned job.
-    pub token: QueryToken,
+    pub token: JobToken,
 }
 
 /// The error message sent back for failed publication request.
@@ -260,7 +260,7 @@ pub struct Unpublish {
     /// The identifier of the topic to unpublish.
     pub topic: TopicId,
     /// A token authenticating the the submitter as a successfully spawned job.
-    pub token: QueryToken,
+    pub token: JobToken,
 }
 
 /// The error message sent back for failed unpublication request.

--- a/src/strymon_rpc/src/coordinator/mod.rs
+++ b/src/strymon_rpc/src/coordinator/mod.rs
@@ -83,7 +83,7 @@ pub enum SubmissionError {
 }
 
 impl Request<CoordinatorRPC> for Submission {
-    type Success = QueryId;
+    type Success = JobId;
     type Error = SubmissionError;
 
     const NAME: CoordinatorRPC = CoordinatorRPC::Submission;
@@ -93,7 +93,7 @@ impl Request<CoordinatorRPC> for Submission {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Termination {
     /// Identifier of the job to terminate.
-    pub query: QueryId,
+    pub query: JobId,
 }
 
 /// The error type for failed job termination requests.
@@ -140,7 +140,7 @@ impl Request<CoordinatorRPC> for AddExecutor {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct QueryToken {
     /// The job identifier of the token owner.
-    pub id: QueryId,
+    pub id: JobId,
     /// A opaque random number only known to the job process and the coordinator.
     pub auth: u64,
 }
@@ -149,7 +149,7 @@ pub struct QueryToken {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AddWorkerGroup {
     /// The identifier of the job this group belongs to.
-    pub query: QueryId,
+    pub query: JobId,
     /// The index of this group within the list of groups of the job.
     pub group: usize,
 }

--- a/src/strymon_rpc/src/coordinator/mod.rs
+++ b/src/strymon_rpc/src/coordinator/mod.rs
@@ -64,7 +64,7 @@ pub enum Placement {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Submission {
     /// Specifies the job executable.
-    pub query: QueryProgram,
+    pub query: JobProgram,
     /// An optional human-readable description.
     pub name: Option<String>,
     /// The placement of workers in the cluster.

--- a/src/strymon_rpc/src/coordinator/mod.rs
+++ b/src/strymon_rpc/src/coordinator/mod.rs
@@ -64,7 +64,7 @@ pub enum Placement {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Submission {
     /// Specifies the job executable.
-    pub query: JobProgram,
+    pub job: JobProgram,
     /// An optional human-readable description.
     pub name: Option<String>,
     /// The placement of workers in the cluster.
@@ -93,7 +93,7 @@ impl Request<CoordinatorRPC> for Submission {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Termination {
     /// Identifier of the job to terminate.
-    pub query: JobId,
+    pub job: JobId,
 }
 
 /// The error type for failed job termination requests.
@@ -149,7 +149,7 @@ pub struct JobToken {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AddWorkerGroup {
     /// The identifier of the job this group belongs to.
-    pub query: JobId,
+    pub job: JobId,
     /// The index of this group within the list of groups of the job.
     pub group: usize,
 }

--- a/src/strymon_rpc/src/executor/mod.rs
+++ b/src/strymon_rpc/src/executor/mod.rs
@@ -71,7 +71,7 @@ impl Request<ExecutorRPC> for SpawnQuery {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TerminateQuery {
     /// The job to terminate.
-    pub query: QueryId,
+    pub query: JobId,
 }
 
 /// The error message returned by the executor if job termination fails.

--- a/src/strymon_rpc/src/executor/mod.rs
+++ b/src/strymon_rpc/src/executor/mod.rs
@@ -19,9 +19,9 @@ use strymon_communication::rpc::{Name, Request};
 #[repr(u8)]
 pub enum ExecutorRPC {
     /// Request to spawn a new job worker group.
-    SpawnQuery = 1,
+    SpawnJob = 1,
     /// Request to terminate a running job.
-    TerminateQuery = 2,
+    TerminateJob = 2,
 }
 
 impl Name for ExecutorRPC {
@@ -38,7 +38,7 @@ impl Name for ExecutorRPC {
 
 /// A request to spawn a new worker group.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SpawnQuery {
+pub struct SpawnJob {
     /// The meta-data of the job worker group to spawn.
     pub query: Job,
     /// The hostlist to be passed to `timely_communication`.
@@ -60,16 +60,16 @@ pub enum SpawnError {
     ExecFailed,
 }
 
-impl Request<ExecutorRPC> for SpawnQuery {
+impl Request<ExecutorRPC> for SpawnJob {
     type Success = ();
     type Error = SpawnError;
 
-    const NAME: ExecutorRPC = ExecutorRPC::SpawnQuery;
+    const NAME: ExecutorRPC = ExecutorRPC::SpawnJob;
 }
 
 /// A request to terminate a running job.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TerminateQuery {
+pub struct TerminateJob {
     /// The job to terminate.
     pub query: JobId,
 }
@@ -83,9 +83,9 @@ pub enum TerminateError {
     OperationNotSupported,
 }
 
-impl Request<ExecutorRPC> for TerminateQuery {
+impl Request<ExecutorRPC> for TerminateJob {
     type Success = ();
     type Error = TerminateError;
 
-    const NAME: ExecutorRPC = ExecutorRPC::TerminateQuery;
+    const NAME: ExecutorRPC = ExecutorRPC::TerminateJob;
 }

--- a/src/strymon_rpc/src/executor/mod.rs
+++ b/src/strymon_rpc/src/executor/mod.rs
@@ -40,7 +40,7 @@ impl Name for ExecutorRPC {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SpawnJob {
     /// The meta-data of the job worker group to spawn.
-    pub query: Job,
+    pub job: Job,
     /// The hostlist to be passed to `timely_communication`.
     pub hostlist: Vec<String>,
 }
@@ -71,7 +71,7 @@ impl Request<ExecutorRPC> for SpawnJob {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TerminateJob {
     /// The job to terminate.
-    pub query: JobId,
+    pub job: JobId,
 }
 
 /// The error message returned by the executor if job termination fails.

--- a/src/strymon_rpc/src/executor/mod.rs
+++ b/src/strymon_rpc/src/executor/mod.rs
@@ -40,7 +40,7 @@ impl Name for ExecutorRPC {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SpawnQuery {
     /// The meta-data of the job worker group to spawn.
-    pub query: Query,
+    pub query: Job,
     /// The hostlist to be passed to `timely_communication`.
     pub hostlist: Vec<String>,
 }

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -37,7 +37,7 @@ terminate() {
 wait_job_output() {
     local executor_log="${OUTDIR}/executor_localhost.log"
     for i in $(seq 10); do
-        if grep -F "QueryId(${1}) |" "${executor_log}" | grep -qE "${2}" ; then
+        if grep -F "JobId(${1}) |" "${executor_log}" | grep -qE "${2}" ; then
             return 0
         fi
         sleep 1


### PR DESCRIPTION
This renames the concept of a "running timely dataflow program" from "query" to "job". While query is a more fitting name, its ambiguity has caused confusion before. By calling this concept a "job", we are much closer to the terminology used in Flink and Spark.

Fixes #36 