### PR TITLE
travis: Run tests in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ language: rust
 rust:
   - stable
   - nightly
-script:
-  - cargo test --verbose --all
-  - bash -x ./tests/tests.sh
+
+script: cargo test --verbose --all
 
 jobs:
   include:
+    - stage: test
+      script: bash -x ./tests/tests.sh
+      rust: stable
     - stage: deploy
       rust: stable
       script: ./bin/build-docs.sh


### PR DESCRIPTION
We can run the unit and integration tests in parallel stages, this
should help with spurious timeouts.

Signed-off-by: Sebastian Wicki <swicki@inf.ethz.ch>