### PR TITLE
strymon_coordinator: #![deny(missing_docs)]

### DIFF
--- a/src/strymon_coordinator/src/handler.rs
+++ b/src/strymon_coordinator/src/handler.rs
@@ -6,6 +6,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! The coordinator request handler.
+//!
+//! The [`Coordinator`](struct.Coordinator.html) type implements most of the coordinator
+//! logic. The [`Coordinator`](struct.Coordinator.html) stores some additional state not
+//! exposed in the catalog, such as connection handles or partially spawned jobs. Clients
+//! submit their requests through a [`CoordinatorRef`](struct.Coordinator.html), which tracks
+//! client-associated state.
 
 use std::io;
 use std::mem;
@@ -34,73 +41,106 @@ use catalog::Catalog;
 
 use super::util::Generator;
 
-struct ExecutorState {
+/// The connection and available `timely_communication` ports of an registered executor.
+struct ExecutorResources {
     tx: Outgoing,
     ports: VecDeque<u16>,
 }
 
-impl ExecutorState {
+impl ExecutorResources {
+    /// Creates a new instance
     fn new(tx: Outgoing, ports: (u16, u16)) -> Self {
         let ports = (ports.0..(ports.1 + 1)).collect();
-        ExecutorState {
+        ExecutorResources {
             tx: tx,
             ports: ports,
         }
     }
 
+    /// Returns `true` if this executor still has free ports
     fn has_ports(&self) -> bool {
         !self.ports.is_empty()
     }
 
+    /// Allocates a port to be assigned to a `timely_communcation` worker.
     fn allocate_port(&mut self) -> u16 {
         self.ports.pop_front().expect("coordinator has no free ports")
     }
 
+    /// Frees a previously allocated port.
     fn free_port(&mut self, port: u16) {
         self.ports.push_back(port);
     }
 
+    /// Sends an asynchronous job spawn request to this executor.
     fn spawn(&self, req: &SpawnJob) -> Response<ExecutorRPC, SpawnJob> {
         debug!("issue spawn request {:?}", req);
         self.tx.request(req)
     }
 
+    /// Sends an asynchronous job termination request to this executor.
     fn terminate(&self, job_id: JobId) -> Response<ExecutorRPC, TerminateJob> {
         self.tx.request(&TerminateJob { job: job_id })
     }
 }
 
+/// Represents the states a job can be in.
 enum JobState {
+    /// The job has been submitted to the system, but not all worker groups have yet registered
+    /// themselves at the coordinator.
     Spawning {
+        /// Meta-data about the job being spawned, stored in the catalog once it is running.
         job: Job,
+        /// A handle to the submitter of this job which we use to send back a response once the
+        /// submitted job is running or if spawning has failed.
         submitter: Sender<Result<JobId, SubmissionError>>,
+        /// A handle to each worker group of this job, which we respond to once all groups have
+        /// registered themselves.
         waiting: Vec<Sender<Result<JobToken, WorkerGroupError>>>,
     },
+    /// A normally running job.
     Running,
+    /// This job is currently being terminated.
     Terminating,
 }
 
-struct WorkerGroup {
+/// The state associated with a job which is not exposed in the catalog.
+struct JobResources {
+    /// The phase of the job.
     state: JobState,
+    /// Number of worker groups this job has
     count: usize,
+    /// Allocated `timely_communication` ports for this job. To be returned to the port pool of
+    /// the corresponding executor once this job terminates.
     ports: Vec<(ExecutorId, u16)>,
+    /// The list of executors currently running this job.
     executors: Vec<ExecutorId>,
 }
 
+/// The coordinator instance, contains the current system state and handles incoming requests.
 pub struct Coordinator {
+    /// A weak reference to `Self`, allowing us to hand out new `Rc` instances
     handle: Weak<RefCell<Coordinator>>,
+    /// Handle to the `tokio-core` reactore for spawning background tasks.
     reactor: Handle,
+    /// The catalog of this coordinator instance.
     catalog: Catalog,
 
+    /// Generates the next job id.
     jobid: Generator<JobId>,
+    /// Generates the next executor id.
     executorid: Generator<ExecutorId>,
 
-    executors: BTreeMap<ExecutorId, ExecutorState>,
-    jobs: BTreeMap<JobId, WorkerGroup>,
+    /// A list of available executors and their available resources.
+    executors: BTreeMap<ExecutorId, ExecutorResources>,
+    /// A list of currently spawning, running or terminating jobs and their resources.
+    jobs: BTreeMap<JobId, JobResources>,
+    /// The list of currently pending (blocking) topic lookups with their response handle.
     lookups: HashMap<String, Vec<Sender<Result<Topic, SubscribeError>>>>,
 }
 
 impl Coordinator {
+    /// Creates a new coordinator instance, returning a cloneable client handle for it.
     pub fn new(catalog: Catalog, reactor: Handle) -> CoordinatorRef {
         let coord = Coordinator {
             handle: Weak::new(),
@@ -119,10 +159,12 @@ impl Coordinator {
         CoordinatorRef::from(coord)
     }
 
+    /// Creates a new reference counted handle to `Self`
     fn handle(&self) -> Rc<RefCell<Coordinator>> {
         self.handle.upgrade().expect("`self` has been deallocated?!")
     }
 
+    /// Handles a job submission request.
     fn submission(&mut self, req: Submission) -> Box<Future<Item=JobId, Error=SubmissionError>> {
         // workaround: prevent closures borrowing `self`
         let handle = self.handle();
@@ -187,11 +229,13 @@ impl Coordinator {
             Vec::new()
         };
 
+        // assemble the hostlist passed down to `timely_communication`
         let hostlist: Vec<String> = executors.iter()
             .zip(ports.iter())
             .map(|(executor, &(_, port))| format!("{}:{}", executor.host, port))
             .collect();
 
+        // submission time (at the coordinator) of the current job
         let start_time = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -206,6 +250,7 @@ impl Coordinator {
             executors: executor_ids.clone(),
             start_time: start_time,
         };
+        // the request to be sent out to all involved executors
         let spawnjob = SpawnJob {
             job: job.clone(),
             hostlist: hostlist,
@@ -240,17 +285,18 @@ impl Coordinator {
             waiting: vec![],
         };
 
-        let worker_group = WorkerGroup {
+        let job_resources = JobResources {
             state: state,
             count: executors.len(),
             ports: ports,
             executors: executor_ids,
         };
-        self.jobs.insert(jobid, worker_group);
+        self.jobs.insert(jobid, job_resources);
 
         Box::new(rx.then(|res| res.expect("submission canceled?!")))
     }
 
+    /// Cancels a pending submission, informing already available workers to shut down.
     fn cancel_submission(&mut self, id: JobId, err: SubmissionError) {
         debug!("canceling pending submission for {:?}", id);
         if let Some(job) = self.jobs.remove(&id) {
@@ -267,6 +313,13 @@ impl Coordinator {
         }
     }
 
+    /// A new worker group (i.e. a process hosting a bunch of worker thread) has announced itself
+    /// at the coordinator. This adds the newly registered group to the list of ready worker groups
+    /// and returns a future which is resolved once all groups have registered themselves.
+    ///
+    /// If the newly added group is the last group to arrive, this method complets the submission
+    /// by adding the job to the catalog, responding to all worker groups and the submitter with
+    /// the job id of the newly spawned job.
     fn add_worker_group(&mut self, id: JobId,_group: usize)
         -> Box<Future<Item=JobToken, Error=WorkerGroupError>>
     {
@@ -324,6 +377,9 @@ impl Coordinator {
         rx
     }
 
+    /// Removes a worker group from the system. If it is the first worker group of a job to
+    /// terminate, we put the job into the `Terminating` state. If it is the last group of a job,
+    /// we remove the job completely from the system.
     fn remove_worker_group(&mut self, id: JobId) {
         let mut job = match self.jobs.entry(id) {
             Entry::Occupied(job) => job,
@@ -353,6 +409,9 @@ impl Coordinator {
         }
     }
 
+    /// Handles a job termination request from a user. This sends a termination request to each
+    /// involved executor. The returned future resolves once either all executors have successfully
+    /// terminated the request, or once of the executors has responded with an error.
     fn termination(&mut self, req: Termination) -> Box<Future<Item=(), Error=TerminationError>> {
         let job_id = req.job;
         // extract the executor ids from the worker groups
@@ -388,7 +447,7 @@ impl Coordinator {
                 }
             });
 
-        // only the first error is propaged back to the caller. otherwise we wait
+        // only the first error is propagated back to the caller. otherwise we wait
         // for all executors to respond before we treat the request as completed
         let terminated = stream::futures_unordered(responses).for_each(|()| {
             Ok(())
@@ -397,11 +456,12 @@ impl Coordinator {
         Box::new(terminated)
     }
 
+    /// Adds a new executor to the system, returning its newly assigned executor id.
     fn add_executor(&mut self, req: AddExecutor, tx: Outgoing) -> ExecutorId {
         let id = self.executorid.generate();
         debug!("adding executor {:?} to pool", id);
 
-        let state = ExecutorState::new(tx, req.ports);
+        let state = ExecutorResources::new(tx, req.ports);
         let executor = Executor {
             id: id,
             host: req.host,
@@ -413,12 +473,15 @@ impl Coordinator {
         id
     }
 
+    /// Removes an executor. It cannot be reached anymore for submission or termiation requests
+    /// after this.
     fn remove_executor(&mut self, id: ExecutorId) {
         debug!("removing executor {:?} from pool", id);
         self.executors.remove(&id);
         self.catalog.remove_executor(id);
     }
 
+    /// Creates a new publication in the catalog, returning the created topic.
     fn publish(&mut self, req: Publish) -> Result<Topic, PublishError> {
         let job = req.token.id;
         let result = self.catalog.publish(job, req.name, req.addr, req.schema);
@@ -433,6 +496,7 @@ impl Coordinator {
         result
     }
 
+    /// Removes a publication from the catalog.
     fn unpublish(&mut self,
                  job_id: JobId,
                  topic_id: TopicId)
@@ -440,6 +504,8 @@ impl Coordinator {
         self.catalog.unpublish(job_id, topic_id)
     }
 
+    /// Creates a new subscription for a topic. The returned future resolves either immediately
+    /// for non-blocking lookups, or once a matching topic has been created by a later publication.
     fn subscribe(&mut self,
                  req: Subscribe)
                  -> Box<Future<Item = Topic, Error = SubscribeError>> {
@@ -469,6 +535,7 @@ impl Coordinator {
         }
     }
 
+    /// Removes a subscription from the catalog.
     fn unsubscribe(&mut self,
                    job_id: JobId,
                    topic_id: TopicId)
@@ -476,6 +543,7 @@ impl Coordinator {
         self.catalog.unsubscribe(job_id, topic_id)
     }
 
+    /// Performs a non-blocking, non-subscribing topic lookup.
     fn lookup(&self, name: &str) -> Result<Topic, ()> {
         match self.catalog.lookup(name) {
             Some(topic) => Ok(topic),
@@ -484,16 +552,22 @@ impl Coordinator {
     }
 }
 
-struct State {
+/// State associated with a specific client.
+struct ClientState {
+    /// If this client is one (or more) job worker groups, keep track of their job tokens.
     job: Vec<JobToken>,
+    /// If this client is one (or more) executors, track their ids for deregistration.
     executor: Vec<ExecutorId>,
+    /// The list of publications issued by this client.
     publication: Vec<(JobId, TopicId)>,
+    /// The list of subscriptions issued by this client.
     subscription: Vec<(JobId, TopicId)>,
 }
 
-impl State {
+impl ClientState {
+    /// Creates a new default instance.
     fn empty() -> Self {
-        State {
+        ClientState {
             job: Vec::new(),
             executor: Vec::new(),
             publication: Vec::new(),
@@ -501,24 +575,42 @@ impl State {
         }
     }
 
+    /// Checks if this client is indeed the job it is claiming to be.
     fn authenticate(&self, auth: &JobToken) -> bool {
         self.job.iter().any(|token| auth == token)
     }
 }
 
+impl Default for ClientState {
+    fn default() -> ClientState {
+            ClientState::empty()
+    }
+}
+
+/// A cloneable reference to the coordinator instance, tracking any state created by this handle.
+///
+/// The initial handle is obtained by creating a new coordinator instance with
+/// [`Coordinator::new`](../struct.Coordinator.html#method.new).
+///
+/// Note that cloning this handle will not clone any tracked state.
 pub struct CoordinatorRef {
     coord: Rc<RefCell<Coordinator>>,
-    state: Rc<RefCell<State>>,
+    state: Rc<RefCell<ClientState>>,
 }
 
 impl CoordinatorRef {
+    /// Creates a new empty instance
     fn from(coord: Rc<RefCell<Coordinator>>) -> Self {
         CoordinatorRef {
             coord: coord,
-            state: Rc::new(RefCell::new(State::empty())),
+            state: Default::default(),
         }
     }
 
+    /// Handles a new job submission request.
+    ///
+    /// The returned future resolves with the allocated job identifier once all processes have
+    /// registered themselves at the coordinator (or when an error occurs).
     pub fn submission(&self,
                       req: Submission)
                       -> Box<Future<Item = JobId, Error = SubmissionError>> {
@@ -526,19 +618,28 @@ impl CoordinatorRef {
         self.coord.borrow_mut().submission(req)
     }
 
+    /// Handles a new job termination request.
+    ///
+    /// The returned future resolves once all executors have acknowledged the request, or the
+    /// first executor has reported an error.
     pub fn termination(&self, req: Termination)
                       -> Box<Future<Item = (), Error = TerminationError>> {
         self.coord.borrow_mut().termination(req)
     }
 
-    pub fn add_executor(&mut self, req: AddExecutor, tx: Outgoing) -> ExecutorId {
+    /// Registers a new executor instance. Returns the newly assigned identifier for this executor.
+    pub fn add_executor(&self, req: AddExecutor, tx: Outgoing) -> ExecutorId {
         trace!("incoming {:?}", req);
         let id = self.coord.borrow_mut().add_executor(req, tx);
         self.state.borrow_mut().executor.push(id);
         id
     }
 
-    pub fn add_worker_group(&mut self, id: JobId, group: usize)
+    /// Marks job worker group (e.g. a process hosting some worker threads) as ready.
+    ///
+    /// The returned future resolves with the job identifier for the newly spawned job once all
+    /// other worker groups have registered themselves, or if an error occured.
+    pub fn add_worker_group(&self, id: JobId, group: usize)
          -> Box<Future<Item = JobToken, Error = WorkerGroupError>>
     {
         trace!("incoming AddWorkerGroup {{ id: {:?} }}", id);
@@ -554,7 +655,8 @@ impl CoordinatorRef {
         Box::new(future)
     }
 
-    pub fn publish(&mut self, req: Publish) -> Result<Topic, PublishError> {
+    /// Creates a new publication in the catalog. Returns the created topic.
+    pub fn publish(&self, req: Publish) -> Result<Topic, PublishError> {
         trace!("incoming {:?}", req);
         let job = req.token;
         if !self.state.borrow().authenticate(&job) {
@@ -572,7 +674,8 @@ impl CoordinatorRef {
             })
     }
 
-    pub fn unpublish(&mut self,
+    /// Removes a publication from the catalog.
+    pub fn unpublish(&self,
                      job: JobToken,
                      topic_id: TopicId)
                      -> Result<(), UnpublishError> {
@@ -592,7 +695,11 @@ impl CoordinatorRef {
             })
     }
 
-    pub fn subscribe(&mut self,
+    /// Handles a new subscription request.
+    ///
+    /// The returned future resolves either immediately for non-blocking lookups, or once a
+    /// matching topic is created by a later publication.
+    pub fn subscribe(&self,
                      req: Subscribe)
                      -> Box<Future<Item = Topic, Error = SubscribeError>> {
         trace!("incoming {:?}", req);
@@ -614,7 +721,8 @@ impl CoordinatorRef {
         Box::new(future)
     }
 
-    pub fn unsubscribe(&mut self,
+    /// Removes a subscription from the catalog.
+    pub fn unsubscribe(&self,
                        job: JobToken,
                        topic_id: TopicId)
                        -> Result<(), UnsubscribeError> {
@@ -641,23 +749,31 @@ impl CoordinatorRef {
             })
     }
 
+    /// Performs a non-blocking, non-subscribing topic lookup.
     pub fn lookup(&self, name: &str) -> Result<Topic, ()> {
         trace!("incoming Lookup {{ name: {:?} }}", name);
         self.coord.borrow().lookup(name)
     }
 
+    /// Forwards an encoded query to the catalog.
+    ///
+    /// The catalog which will decode and execute the query and respond to it immediately. Might
+    /// fail if the request could not be decoded.
     pub fn catalog_request(&self, req: RequestBuf<CatalogRPC>) -> io::Result<()> {
         self.coord.borrow().catalog.request(req)
     }
 }
 
-// will only clone the coordinator ref, not the tracked calls
+/// Performs a (shallow) clone to obtain a new handle to the coordinator.
+///
+/// This will not clone any state tracked by the `self`.
 impl Clone for CoordinatorRef {
     fn clone(&self) -> Self {
         CoordinatorRef::from(self.coord.clone())
     }
 }
 
+/// Removes any state associated with the client owning this handle.
 impl Drop for CoordinatorRef {
     fn drop(&mut self) {
         // here we clean up any state that we might own

--- a/src/strymon_coordinator/src/util.rs
+++ b/src/strymon_coordinator/src/util.rs
@@ -9,6 +9,7 @@
 use std::ops::RangeFrom;
 use std::marker::PhantomData;
 
+/// A helper type for generating sequential identifiers
 #[derive(Debug, Clone)]
 pub struct Generator<T> {
     generator: RangeFrom<u64>,
@@ -16,6 +17,7 @@ pub struct Generator<T> {
 }
 
 impl<T: From<u64>> Generator<T> {
+    /// Creates a new generator starting at `From::from(0)`
     pub fn new() -> Self {
         Generator {
             generator: 0..,
@@ -23,6 +25,7 @@ impl<T: From<u64>> Generator<T> {
         }
     }
 
+    /// Generates the next sequence number.
     pub fn generate(&mut self) -> T {
         From::from(self.generator.next().unwrap())
     }


### PR DESCRIPTION
This documents the internal coordinator APIs (plus some minor code refactoring).

Signed-off-by: Sebastian Wicki <swicki@inf.ethz.ch>