### PR TITLE
Implement job submission timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,14 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "futures-timer"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +584,7 @@ name = "strymon_coordinator"
 version = "0.1.0"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-timer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "strymon_communication 0.1.2",
@@ -947,6 +956,7 @@ dependencies = [
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0bab5b5e94f5c31fc764ba5dd9ad16568aae5d4825538c01d6bca680c9bf94a7"
+"checksum futures-timer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a5cedfe9b6dc756220782cc1ba5bcb1fa091cdcba155e40d3556159c3db58043"
 "checksum getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "b900c08c1939860ce8b54dc6a89e26e00c04c380fd0e09796799bd7f12861e05"
 "checksum iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6e8b9c2247fcf6c6a1151f1156932be5606c9fd6f55a2d7f9fc1cb29386b2f7"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,28 +808,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-timer"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "topology_generator"
 version = "0.1.1"
 dependencies = [
  "abomonation 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "abomonation_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-timer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "strymon_communication 0.1.2",
  "strymon_job 0.1.2",
  "timely 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "typename 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1011,7 +1002,6 @@ dependencies = [
 "checksum tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "514aae203178929dbf03318ad7c683126672d4d96eccb77b29603d33c9e25743"
 "checksum tokio-process 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2e76e0cd21a4ae5362697e85f98aa5d26c88f09ce9fc367b57c0643ba0b022c2"
 "checksum tokio-signal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "57c4031b97651d28c87a0a071e1c2809d70609d3120ce285b302eb7d52c96906"
-"checksum tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6131e780037787ff1b3f8aad9da83bca02438b72277850dd6ad0d455e0e20efc"
 "checksum typename 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07c6494e04fa9e31404425680954aac69080337a6e9a946b475578962674482f"
 "checksum typename_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9be293eee17e33e38c7f0c9ab50b4b8a3a41599bff6325fba57427713a7a3af1"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"

--- a/apps/topology-generator/Cargo.toml
+++ b/apps/topology-generator/Cargo.toml
@@ -12,7 +12,7 @@ serde = "1.0"
 serde_derive = "1.0"
 typename = "0.1"
 futures = "0.1"
-tokio-timer = "0.1"
+futures-timer = "0.1"
 
 [dependencies.strymon_job]
 path = "../../src/strymon_job"

--- a/src/strymon_coordinator/Cargo.toml
+++ b/src/strymon_coordinator/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Sebastian Wicki <swicki@inf.ethz.ch>"]
 [dependencies]
 log = "0.4"
 futures = "0.1"
+futures-timer = "0.1"
 rand = "0.3"
 tokio-core = "0.1"
 

--- a/src/strymon_coordinator/src/lib.rs
+++ b/src/strymon_coordinator/src/lib.rs
@@ -63,6 +63,7 @@
 extern crate log;
 extern crate rand;
 extern crate futures;
+extern crate futures_timer;
 extern crate tokio_core;
 
 extern crate strymon_rpc;

--- a/src/strymon_rpc/src/coordinator/mod.rs
+++ b/src/strymon_rpc/src/coordinator/mod.rs
@@ -11,6 +11,8 @@
 
 pub mod catalog;
 
+use std::io;
+
 use num_traits::FromPrimitive;
 
 use strymon_model::*;
@@ -80,6 +82,16 @@ pub enum SubmissionError {
     ExecutorUnreachable,
     /// An executor reported an error while spawning.
     SpawnError(::executor::SpawnError),
+    /// The coordinator timed out waiting for worker groups to arrive
+    TimedOut,
+    /// An unknown error occured.
+    Other,
+}
+
+impl From<io::Error> for SubmissionError {
+    fn from(_: io::Error) -> SubmissionError {
+        SubmissionError::TimedOut
+    }
 }
 
 impl Request<CoordinatorRPC> for Submission {


### PR DESCRIPTION
This adds a timeout for job submissions, ensuring that the pending job is removed if one of its worker group never responds. Fixes bug #17.

This PR also replaces the `tokio-timer` dependency with `futures-timer`, which is has a slimmer API.